### PR TITLE
Add initial_prompt config option

### DIFF
--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -31,6 +31,9 @@ whisper: # Whisper AI Model Settings
   # Transcription quality settings
   beam_size: 5  # Higher = more accurate but slower (1-10)
 
+  # Initial prompt to guide transcription style, language variant, or script
+  initial_prompt: ""
+
   # Custom hotwords — words the model should favor during transcription
   # Useful for names, technical terms, or domain-specific vocabulary
   # Example: ["CTranslate2", "PyInstaller", "Whisper Key"]

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -107,6 +107,7 @@ def setup_whisper_engine(whisper_config, vad_manager, model_registry, log_transc
         compute_type=whisper_config['compute_type'],
         language=whisper_config['language'],
         beam_size=whisper_config['beam_size'],
+        initial_prompt=whisper_config.get('initial_prompt', ''),
         hotwords=whisper_config.get('hotwords', []),
         vad_manager=vad_manager,
         model_registry=model_registry,

--- a/src/whisper_key/whisper_engine.py
+++ b/src/whisper_key/whisper_engine.py
@@ -14,6 +14,7 @@ class WhisperEngine:
                  compute_type: str = "int8",
                  language: str = None,
                  beam_size: int = 5,
+                 initial_prompt: str = "",
                  hotwords: list = None,
                  vad_manager = None,
                  model_registry = None,
@@ -24,6 +25,7 @@ class WhisperEngine:
         self.compute_type = compute_type
         self.language = None if language == 'auto' else language
         self.beam_size = beam_size
+        self.initial_prompt = initial_prompt or None
         self.hotwords = ", ".join(hotwords) if hotwords else None
         self.model = None
         self.logger = logging.getLogger(__name__)
@@ -161,6 +163,8 @@ class WhisperEngine:
                 language=self.language,
                 condition_on_previous_text=False,
             )
+            if self.initial_prompt:
+                transcribe_kwargs["initial_prompt"] = self.initial_prompt
             if self.hotwords:
                 transcribe_kwargs["hotwords"] = self.hotwords
 


### PR DESCRIPTION
## Summary
- Adds `initial_prompt` as a configurable whisper setting in `user_settings.yaml`
- Passes it through to faster-whisper's `transcribe()` call
- Useful for guiding transcription style, language variant (e.g. Cantonese vs Mandarin), or script (Traditional vs Simplified Chinese)

Closes #38

## Test plan
- [x] App starts without errors
- [x] Set `initial_prompt` in user_settings.yaml and verify it persists across restarts
- [x] Verify transcription output is influenced by the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)