### PR TITLE
Add push-to-talk recording mode

### DIFF
--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -152,6 +152,11 @@ hotkey: # Hotkey Configuration
   # Note: On macOS, ESC is system-reserved
   cancel_combination: "esc | macos: shift"
 
+  # Recording mode
+  # "toggle" = press hotkey to start, press stop key to stop (default)
+  # "push_to_talk" = hold hotkey to record, release to stop and transcribe
+  recording_mode: toggle
+
   # Key combination for voice command mode
   # Records speech and matches against user-defined commands
   command_hotkey: "alt+win | macos: fn+command"

--- a/src/whisper_key/config_manager.py
+++ b/src/whisper_key/config_manager.py
@@ -239,6 +239,12 @@ class ConfigManager:
         return beautify_hotkey(self.config['hotkey']['stop_key'])
 
     def print_stop_instructions_based_on_config(self):
+        recording_mode = self.config['hotkey'].get('recording_mode', 'toggle')
+
+        if recording_mode == 'push_to_talk':
+            print("   Release key to stop and transcribe")
+            return
+
         stop_key = self._get_stop_key_display()
         auto_paste_enabled = self.config['clipboard']['auto_paste']
         auto_send_key = self.config['hotkey'].get('auto_send_key', '')
@@ -253,7 +259,9 @@ class ConfigManager:
 
     def print_startup_hotkey_instructions(self):
         recording_hotkey = beautify_hotkey(self.config['hotkey']['recording_hotkey'])
-        print(f"   [{recording_hotkey}] for transcription")
+        recording_mode = self.config['hotkey'].get('recording_mode', 'toggle')
+        mode_hint = " (hold to record)" if recording_mode == "push_to_talk" else ""
+        print(f"   [{recording_hotkey}] for transcription{mode_hint}")
 
         if self.get_voice_commands_config().get('enabled', True):
             command_hotkey = self.config['hotkey'].get('command_hotkey')
@@ -397,6 +405,10 @@ def validate_config(config, default_config, logger):
     _validate_numeric_range(config, default_config, 'vad.vad_offset_threshold', logger, min_val=0.0, max_val=1.0)
     _validate_numeric_range(config, default_config, 'vad.vad_min_speech_duration', logger, min_val=0.001, max_val=5.0)
     _validate_numeric_range(config, default_config, 'vad.vad_silence_timeout_seconds', logger, min_val=1.0, max_val=36000.0)
+
+    recording_mode = _get_config_value_at_path(config, 'hotkey.recording_mode')
+    if recording_mode not in ('toggle', 'push_to_talk'):
+        _set_to_default(config, default_config, 'hotkey.recording_mode', recording_mode, logger)
 
     stop_key = _get_config_value_at_path(config, 'hotkey.stop_key')
     auto_send_key = _get_config_value_at_path(config, 'hotkey.auto_send_key')

--- a/src/whisper_key/hotkey_listener.py
+++ b/src/whisper_key/hotkey_listener.py
@@ -6,13 +6,14 @@ from .state_manager import StateManager
 class HotkeyListener:
     def __init__(self, state_manager: StateManager, recording_hotkey: str, stop_key: str,
                  auto_send_key: str = None, cancel_combination: str = None,
-                 command_hotkey: str = None):
+                 command_hotkey: str = None, recording_mode: str = "toggle"):
         self.state_manager = state_manager
         self.recording_hotkey = recording_hotkey
         self.stop_key = stop_key
         self.auto_send_key = auto_send_key
         self.cancel_combination = cancel_combination
         self.command_hotkey = command_hotkey
+        self.recording_mode = recording_mode
         self.keys_armed = True
         self.is_listening = False
         self.logger = logging.getLogger(__name__)
@@ -24,11 +25,19 @@ class HotkeyListener:
     def _setup_hotkeys(self):
         hotkey_configs = []
 
-        hotkey_configs.append({
-            'combination': self.recording_hotkey,
-            'callback': self._standard_hotkey_pressed,
-            'name': 'standard'
-        })
+        if self.recording_mode == "push_to_talk":
+            hotkey_configs.append({
+                'combination': self.recording_hotkey,
+                'callback': self._standard_hotkey_pressed,
+                'release_callback': self._push_to_talk_released,
+                'name': 'standard (push-to-talk)'
+            })
+        else:
+            hotkey_configs.append({
+                'combination': self.recording_hotkey,
+                'callback': self._standard_hotkey_pressed,
+                'name': 'standard'
+            })
 
         hotkey_configs.append({
             'combination': self.stop_key,
@@ -82,6 +91,10 @@ class HotkeyListener:
         self.logger.info(f"Standard hotkey pressed: {self.recording_hotkey}")
         self.keys_armed = False
         self.state_manager.start_recording()
+
+    def _push_to_talk_released(self):
+        self.logger.info("Push-to-talk key released")
+        self.state_manager.stop_recording()
 
     def _stop_key_pressed(self):
         self.logger.debug(f"Stop key pressed: {self.stop_key}, keys_armed={self.keys_armed}")
@@ -146,7 +159,7 @@ class HotkeyListener:
             self.logger.error(f"Error stopping hotkey listener: {e}")
 
     def change_hotkey_config(self, setting: str, value):
-        valid_settings = ['recording_hotkey', 'stop_key', 'auto_send_key', 'cancel_combination', 'command_hotkey']
+        valid_settings = ['recording_hotkey', 'stop_key', 'auto_send_key', 'cancel_combination', 'command_hotkey', 'recording_mode']
 
         if setting not in valid_settings:
             raise ValueError(f"Invalid setting '{setting}'. Valid options: {valid_settings}")

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -175,7 +175,8 @@ def setup_hotkey_listener(hotkey_config, state_manager, voice_commands_enabled=T
         stop_key=hotkey_config['stop_key'],
         auto_send_key=hotkey_config.get('auto_send_key'),
         cancel_combination=hotkey_config.get('cancel_combination'),
-        command_hotkey=hotkey_config.get('command_hotkey') if voice_commands_enabled else None
+        command_hotkey=hotkey_config.get('command_hotkey') if voice_commands_enabled else None,
+        recording_mode=hotkey_config.get('recording_mode', 'toggle')
     )
 
 def shutdown_app(hotkey_listener: HotkeyListener, state_manager: StateManager, logger: logging.Logger):


### PR DESCRIPTION
## Summary
- New `hotkey.recording_mode` config option: `"toggle"` (default) or `"push_to_talk"`
- In push-to-talk mode, hold the recording hotkey to record, release to stop and transcribe
- Stop key, auto-send key, and cancel key still work as fallbacks

## Test plan
- [x] Set `recording_mode: push_to_talk` in user_settings.yaml and verified hold-to-record works
- [x] Default toggle mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)