### PR TITLE
Add built-in HTTP trigger for remote control

### DIFF
--- a/doc/PLAN_OVERLAY_CONFIG.md
+++ b/doc/PLAN_OVERLAY_CONFIG.md
@@ -1,0 +1,212 @@
+# Plan: Konfigurierbares Preview Overlay
+
+---
+
+## Ueberblick
+
+Das Preview-Overlay soll vollstaendig konfigurierbar sein:
+- **Welcher Monitor**: Cursor-Position, Focus-Follow, fester Monitor, alle Monitore
+- **Position**: bottom_center, top_center, etc.
+- **Stil**: Schriftgroesse, Transparenz, Farben
+- **Einstellbar per**: Config-File + System Tray Context-Menu + HTTP API
+
+---
+
+## 1. Config-Schema
+
+### Neue Config unter `listening.overlay:`
+
+```yaml
+listening:
+  preview_enabled: false          # bestehend
+  preview_show_tooltip: true      # bestehend
+  preview_show_overlay: false     # bestehend
+
+  overlay:
+    monitor: follow_focus         # "follow_focus" | "cursor" | "primary" | "all" | 1 | 2 | 3...
+    position: bottom_center       # bottom_center | top_center | bottom_left | bottom_right | top_left | top_right | center
+    margin: 80                    # Pixel-Abstand vom Rand (0-500)
+    font_size: 18                 # 8-72
+    opacity: 0.85                 # 0.1-1.0
+    bg_color: "#1a1a2e"
+    text_color: "#ffffff"
+```
+
+### Monitor-Modi
+
+| Wert | Verhalten |
+|---|---|
+| `follow_focus` | Overlay auf dem Monitor des aktiv fokussierten Fensters (via GetForegroundWindow + MonitorFromWindow) |
+| `cursor` | Overlay auf dem Monitor unter der Maus (aktuelles Verhalten, GetCursorPos + MonitorFromPoint) |
+| `primary` | Immer auf dem primaeren Monitor |
+| `all` | Ein Overlay-Fenster pro Monitor gleichzeitig |
+| `1`, `2`, `3`... | Fester Monitor nach Index |
+
+### Positions-Berechnung
+
+```
+Position = Monitor-Work-Area (ohne Taskbar) + Margin + Fenster-Groesse
+
+bottom_center: x = mon_x + (mon_w - win_w) / 2,  y = mon_y + mon_h - win_h - margin
+top_center:    x = mon_x + (mon_w - win_w) / 2,  y = mon_y + margin
+bottom_left:   x = mon_x + margin,                y = mon_y + mon_h - win_h - margin
+bottom_right:  x = mon_x + mon_w - win_w - margin, y = mon_y + mon_h - win_h - margin
+...
+```
+
+---
+
+## 2. System Tray Menu
+
+```
+Preview ->
+  [x] Enabled
+  ---
+  Overlay ->
+    [x] Show Overlay
+    ---
+    Monitor ->
+      * Follow Focus
+      o Cursor Position
+      o Primary Monitor
+      o All Monitors
+      ---
+      o Monitor 1 (\\.\DISPLAY1)
+      o Monitor 2 (\\.\DISPLAY2)
+    Position ->
+      * Bottom Center
+      o Top Center
+      o Bottom Left
+      o Bottom Right
+```
+
+Monitor-Liste wird dynamisch generiert via `EnumDisplayMonitors`. Stil-Optionen (font, opacity, colors) nur per Config-File — nicht im Tray (wuerde ueberladen).
+
+---
+
+## 3. HTTP API
+
+```
+GET /overlay                       → {"monitor": "follow_focus", "position": "bottom_center", "monitors": [...]}
+GET /overlay/toggle                → Overlay ein/aus (preview_show_overlay)
+GET /overlay/monitor/follow_focus  → Monitor-Modus aendern
+GET /overlay/monitor/cursor        → Monitor-Modus aendern
+GET /overlay/monitor/primary       → Monitor-Modus aendern
+GET /overlay/monitor/all           → Monitor-Modus aendern
+GET /overlay/monitor/1             → Fester Monitor
+GET /overlay/position/bottom_center → Position aendern
+GET /overlay/position/top_center    → Position aendern
+```
+
+---
+
+## 4. Implementierungsplan
+
+### Phase A: Monitor-Utility Modul (Basis)
+
+**Neue Datei:** `src/whisper_key/platform/windows/monitors.py`
+
+Win32 Monitor-Utilities via ctypes (kein neues Dependency):
+- `enumerate_monitors() -> list[MonitorInfo]` — Alle Monitore mit Index, Name, Rect, Work-Area, Primary-Flag
+- `get_monitor_by_index(index) -> MonitorInfo`
+- `get_primary_monitor() -> MonitorInfo`
+- `get_monitor_at_cursor() -> MonitorInfo`
+- `get_monitor_of_focused_window() -> MonitorInfo` — GetForegroundWindow + MonitorFromWindow
+- `MonitorInfo` dataclass mit: index, name, x, y, w, h, work_x, work_y, work_w, work_h, is_primary
+
+**KRITISCH:** `ctypes.windll.shcore.SetProcessDpiAwareness(2)` muss VOR `tk.Tk()` aufgerufen werden — sonst falsche Koordinaten bei Mixed-DPI.
+
+### Phase B: Overlay Refactoring
+
+**Datei:** `src/whisper_key/preview_overlay.py`
+
+Refactoring der bestehenden Klasse:
+- Konstruktor bekommt overlay_config dict (monitor, position, margin, font_size, opacity, colors)
+- `_resolve_monitor()` — je nach Modus: follow_focus, cursor, primary, fixed(N)
+- `_calculate_position(monitor_info)` — Position berechnen basierend auf position + margin
+- Stil-Parameter aus Config statt hardcoded
+- Fuer "all": Multi-Window mit `Toplevel()` pro Monitor (nur wenn `monitor: "all"`)
+- DPI-Awareness setzen bei Init
+
+### Phase C: Config + Persistenz
+
+**Dateien:** `config.defaults.yaml`, `config_manager.py`
+
+- Neue `overlay:` Sub-Sektion unter `listening:`
+- `get_overlay_config() -> dict`
+- `update_overlay_setting(key, value)` — persistiert in user_settings.yaml
+- Validierung: monitor (str|int), position (enum), margin (0-500), font_size (8-72), opacity (0.1-1.0)
+
+### Phase D: Tray Integration
+
+**Datei:** `system_tray.py`
+
+- "Preview" wird Submenu statt Checkbox
+- "Overlay" Sub-Submenu mit:
+  - Show Overlay Checkbox
+  - Monitor Radiobuttons (dynamisch + fixe Optionen)
+  - Position Radiobuttons
+- Callbacks an `state_manager` / `config_manager`
+
+### Phase E: HTTP + StateManager
+
+**Dateien:** `http_trigger.py`, `state_manager.py`
+
+- /overlay/* Endpoints in http_trigger.py
+- state_manager: `set_overlay_monitor()`, `set_overlay_position()`, `get_overlay_config()`
+- Overlay zur Laufzeit rekonfigurieren (kein Neustart)
+
+---
+
+## 5. Betroffene Dateien
+
+| Datei | Aenderung |
+|---|---|
+| `platform/windows/monitors.py` | NEU — Monitor-Enumeration |
+| `preview_overlay.py` | Refactoring — Config-driven, Multi-Monitor, DPI |
+| `config.defaults.yaml` | overlay: Sub-Sektion |
+| `config_manager.py` | get/update overlay config, Validierung |
+| `system_tray.py` | Preview Submenu mit Monitor/Position |
+| `http_trigger.py` | /overlay/* Endpoints |
+| `state_manager.py` | Overlay-Config Setter/Getter |
+| `main.py` | Overlay-Config an PreviewOverlay durchreichen |
+
+---
+
+## 6. Interaktions-Matrix
+
+| preview_enabled | preview_show_overlay | monitor | Verhalten |
+|---|---|---|---|
+| false | * | * | Kein Preview, kein Overlay |
+| true | false | * | Preview aktiv (HTTP/Tooltip), kein Overlay |
+| true | true | follow_focus | Overlay auf Monitor des fokussierten Fensters |
+| true | true | cursor | Overlay auf Monitor unter Mauszeiger |
+| true | true | primary | Overlay auf primaerer Monitor |
+| true | true | all | Ein Overlay pro Monitor |
+| true | true | 2 | Overlay auf Monitor 2 (Fallback: primary) |
+
+---
+
+## 7. Risiken + Mitigations
+
+| Risiko | Mitigation |
+|---|---|
+| DPI-Scaling falsche Koordinaten | SetProcessDpiAwareness(2) bei App-Start |
+| Monitor-Index aendert sich bei Hotplug | Fallback auf primary bei ungueltigem Index |
+| "all" Mode: N tkinter Fenster | Toplevel() statt Tk(), lazy create/destroy |
+| Focus-Follow Polling-Last | Kein Polling noetig — bei jedem update_text() Monitor neu bestimmen (1.5s Intervall) |
+| macOS Kompatibilitaet | monitors.py nur unter platform/windows/, macOS Fallback auf primary |
+| Tray-Menu zu tief verschachtelt | Max 3 Ebenen (Preview → Overlay → Monitor/Position) |
+
+---
+
+## 8. Aufwandsschaetzung
+
+| Phase | Aufwand |
+|---|---|
+| A: Monitor-Utility | 2-3h |
+| B: Overlay Refactoring | 3-4h |
+| C: Config + Persistenz | 1-2h |
+| D: Tray Integration | 2-3h |
+| E: HTTP + StateManager | 1-2h |
+| **Gesamt** | **9-14h** |

--- a/doc/agenten/code-analyst/analyse.md
+++ b/doc/agenten/code-analyst/analyse.md
@@ -1,0 +1,280 @@
+# Code-Analyse: Overlay, System Tray & Monitor-Handling
+
+## 1. IST-Zustand
+
+### 1.1 Preview Overlay (`preview_overlay.py`, 115 Zeilen)
+
+**Architektur:**
+- Eigener tkinter-Thread (daemon), gestartet im `__init__`
+- `threading.Event` (`_ready`) synchronisiert Initialisierung (max 5s timeout)
+- Ein einziges `tk.Tk()` Fenster, kein zweites Toplevel
+- Fenster ist `overrideredirect(True)` + `topmost` + alpha 0.85
+
+**Thread-Safety-Pattern:**
+- Alle UI-Mutationen laufen ueber `self._root.after(0, callback)` — das ist korrekt, weil `after()` in die tkinter-Mainloop einreiht
+- Aeussere Methoden (`update_text`, `show`, `hide`) sind threadsafe aufrufbar
+
+**Positionierung (`_position_bottom_center`):**
+- Ruft `_get_active_monitor()` auf — ermittelt den Monitor unter dem **Mauszeiger**
+- Positioniert das Fenster horizontal zentriert, 80px ueber dem unteren Rand der Work Area (`rcWork`)
+- Wird bei jedem `update_text()` Aufruf neu berechnet — d.h. der Monitor wird bei jedem Text-Update bestimmt
+
+**Monitor-Erkennung (`_get_active_monitor`):**
+- Win32 API direkt via ctypes:
+  1. `GetCursorPos()` — aktuelle Mausposition
+  2. `MonitorFromPoint(point, 2)` — Monitor der den Punkt enthaelt (Flag 2 = MONITOR_DEFAULTTONEAREST)
+  3. `GetMonitorInfoW()` — Work Area Bounds (rcWork, exkl. Taskbar)
+- Fallback bei Exception: primaerer Monitor via `winfo_screenwidth()/winfo_screenheight()`
+- **Kein Caching** — wird bei jedem Text-Update neu abgefragt
+- **Nur Windows** — kein macOS-Pfad (ctypes.windll ist Windows-only)
+
+**Lifecycle:**
+- Erstellt in `main.py` Zeile 330, nur wenn `listening.preview_show_overlay == True`
+- Zugewiesen an `state_manager.preview_overlay`
+- Kein expliziter `destroy()`/Cleanup — Thread ist daemon, stirbt mit Prozess
+
+### 1.2 System Tray (`system_tray.py`, 423 Zeilen)
+
+**Architektur:**
+- pystray-basiert, laeuft via `icon.run_detached()` (eigener Thread)
+- Haelt Referenzen auf `state_manager`, `config_manager`, `model_registry`
+- Menu wird bei jedem State-Update komplett neu erzeugt (`_create_menu()`)
+
+**Menu-Struktur (aktuell):**
+```
+Open log file...
+Open model cache...
+---
+Open config folder...
+Open settings file...
+Open commands file...        (nur wenn voice_commands.enabled)
+---
+Audio Host >                 (Submenu, Radiobuttons)
+Audio Source >               (Submenu, Radiobuttons)
+---
+Auto-paste                   (Radio)
+Copy to clipboard            (Radio)
+---
+Model: {current} >           (Submenu, Radiobuttons pro Gruppe mit Separatoren)
+---
+Listening Mode >             (Submenu: Hotkey/Continuous/Wake Word als Radio)
+Preview                      (Checkbox)
+---
+Exit
+```
+
+**Pattern fuer Radiobutton-Gruppen (Beispiel: Listening Mode):**
+```python
+# 1. Aktuellen Wert lesen
+current_listening_mode = mode_info["mode"]
+
+# 2. Closure-Factories fuer checked/action
+def make_mode_selector(mode):
+    return lambda icon, item: self._select_listening_mode(mode)
+
+def make_is_mode(mode_value):
+    return lambda item: current_listening_mode == mode_value
+
+# 3. MenuItem mit radio=True, checked=closure
+pystray.MenuItem("Hotkey", make_mode_selector(ListeningMode.HOTKEY),
+                 radio=True, checked=make_is_mode("hotkey"))
+
+# 4. Handler ruft state_manager + rebuild menu
+def _select_listening_mode(self, mode):
+    self.state_manager.set_listening_mode(mode)
+    self.icon.menu = self._create_menu()
+```
+
+**Config-Aenderung zur Laufzeit:**
+- Tray-Handler ruft `state_manager.xyz()` — der ruft `config_manager.update_user_setting(section, key, value)`
+- `update_user_setting` aendert `self.config` in-memory + schreibt `_save_user_overrides()` (nur Diffs zum Default)
+- Danach `self.icon.menu = self._create_menu()` — Menu wird komplett neu aufgebaut
+
+**Submenu-Pattern:**
+```python
+pystray.MenuItem("Label", pystray.Menu(*sub_items))
+```
+pystray unterstuetzt beliebige Tiefe, aber tiefe Verschachtelung ist UX-maessig problematisch.
+
+### 1.3 Config (`config.defaults.yaml` + `config_manager.py`)
+
+**Relevante bestehende Keys:**
+```yaml
+listening:
+  mode: hotkey
+  preview_enabled: false
+  preview_show_tooltip: true
+  preview_show_overlay: false    # <-- Overlay an/aus
+  preview_interval_sec: 1.5
+  preview_max_audio_seconds: 30.0
+  pre_buffer_duration_sec: 0.3
+  post_speech_silence_ms: 800
+  max_speech_duration_sec: 60.0
+  min_speech_duration_sec: 0.5
+```
+
+**Es gibt KEINE Config-Keys fuer:**
+- Monitor-Auswahl (fester Monitor, Focus-Follow, alle Monitore)
+- Overlay-Position (immer bottom-center)
+- Overlay-Aussehen (Farbe, Groesse, Transparenz)
+
+### 1.4 State Manager (`state_manager.py`)
+
+**Overlay-Interaktion:**
+- `preview_overlay` ist ein optionales Attribut (None oder PreviewOverlay-Instanz)
+- Wird in `handle_streaming_result()` angesprochen:
+  - Bei nicht-finalem Text: `preview_overlay.update_text(text)` — zeigt laufende Vorschau
+  - Bei finalem Text: `preview_overlay.update_text(text)` + `Timer(2.0, hide)` — 2s Timeout dann verstecken
+- `preview_show_overlay` boolean entscheidet ob Overlay-Methoden aufgerufen werden
+
+---
+
+## 2. Gaps fuer neue Features
+
+### 2.1 "Fester Monitor" Konfiguration
+
+**Was fehlt:**
+- Config-Key: `listening.overlay_monitor` (z.B. `"auto"`, `1`, `2`, `3`, ...)
+- Methode zum Enumerieren aller Monitore mit Name/Index (`EnumDisplayMonitors` auf Windows)
+- `_get_active_monitor()` muss den konfigurierten Monitor zurueckgeben statt immer Cursor-Position
+- Tray-Submenu: "Overlay Monitor > Auto (Maus) / Monitor 1 / Monitor 2 / ..."
+- Handler: `_select_overlay_monitor(monitor_id)` analog zu `_select_audio_device`
+
+**Implementierungshinweise:**
+- Monitor-Enumeration via `EnumDisplayMonitors` + `GetMonitorInfoW` (ctypes, analog zum bestehenden Code)
+- Monitor-IDs koennen sich aendern (wie Audio-Devices) — Monitor-Name als Identifier robuster als Index
+- Braucht plattform-abstrahierten Monitor-Enumeration-Layer (macOS: NSScreen)
+
+### 2.2 "Focus-Follow" (Overlay folgt Fokusfenster)
+
+**Was fehlt:**
+- Config-Key: z.B. `listening.overlay_monitor: "focus"` als Modus
+- Ermittlung des Fokus-Fensters: `GetForegroundWindow()` + `MonitorFromWindow()` (Windows)
+- Polling oder Event-Hook:
+  - Option A: `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` — eventbasiert, effizienter
+  - Option B: Polling in Intervallen (z.B. 200ms) — einfacher, aber CPU-Last
+- `_get_active_monitor()` muss zwischen Cursor/Focus/Fixed Modus unterscheiden
+- Muss auch bei Aufruf ausserhalb von `update_text()` funktionieren (z.B. Pre-Positioning)
+
+**Implementierungshinweise:**
+- `SetWinEventHook` braucht eine Message-Pump — tkinter-Mainloop koennte dafuer genutzt werden
+- Alternativ: Hook im tkinter-Thread registrieren
+- macOS: `NSWorkspace.shared().frontmostApplication` + Window-Bounds via Accessibility API
+
+### 2.3 "Alle Monitore" (Overlay auf jedem Monitor)
+
+**Was fehlt:**
+- Config-Key: z.B. `listening.overlay_monitor: "all"`
+- Mehrere tkinter-Fenster gleichzeitig — ein Toplevel pro Monitor
+- Synchrones Text-Update auf allen Fenstern
+- Lifecycle-Management: Fenster erstellen/zerstoeren bei Monitor-Hotplug
+
+**Implementierungshinweise:**
+- tkinter erlaubt nur EIN `Tk()` — weitere Fenster muessen `Toplevel(root)` sein
+- Alle muessen im selben Thread laufen (tkinter ist single-threaded)
+- Bestehender Code hat `self._root = tk.Tk()` + `self._label` — muss zu einer Liste von Fenstern/Labels refactored werden
+- Performance: N Fenster mit identischem Text — `update_text` loopt ueber alle
+
+### 2.4 Context-Menu Einstellungen im Tray
+
+**Was fehlt (neue Menu-Eintraege):**
+```
+Overlay Monitor >
+  Auto (Mauszeiger)        (Radio, Default)
+  Focus-Follow             (Radio)
+  Alle Monitore            (Radio)
+  ---
+  Monitor 1: "Dell U2720Q"  (Radio)
+  Monitor 2: "LG 27UK850"   (Radio)
+```
+
+**Pattern folgt dem bestehenden Radiobutton-Muster** (s. Listening Mode):
+1. Monitor-Liste dynamisch via Enumeration
+2. Closure-Factories fuer `checked` und `action`
+3. Handler ruft `state_manager` + `config_manager.update_user_setting` + Menu-Rebuild
+
+**Platzierung im Menu:** nach "Preview" Checkbox, vor dem letzten Separator/Exit.
+
+### 2.5 Neue Config-Keys (Vorschlag)
+
+```yaml
+listening:
+  # ... bestehende Keys ...
+  overlay_monitor: "auto"
+  # Moegliche Werte:
+  #   "auto"    — Monitor unter Mauszeiger (aktuelles Verhalten)
+  #   "focus"   — Monitor des Fokus-Fensters
+  #   "all"     — alle Monitore gleichzeitig
+  #   1, 2, ... — fester Monitor-Index
+```
+
+---
+
+## 3. Risiken & Technische Bedenken
+
+### 3.1 tkinter Thread-Safety bei Monitor-Wechsel
+
+**Risiko: MITTEL**
+- Aktuell korrekt geloest: alle UI-Ops laufen via `root.after(0, callback)`
+- Bei Focus-Follow: der Monitor-Wert muss atomar lesbar sein (z.B. via threading.Lock oder da nur im tkinter-Thread gelesen)
+- Bei "alle Monitore": Fenster-Erstellung muss im tkinter-Thread passieren (`after()`-Pattern beibehalten)
+- **Achtung:** `_get_active_monitor()` wird aktuell INNERHALB von `_position_bottom_center()` aufgerufen, was wiederum in `_update()` via `after()` laeuft — d.h. bereits im tkinter-Thread. Das ist korrekt und muss so bleiben.
+
+### 3.2 Performance bei Polling fuer Focus-Follow
+
+**Risiko: NIEDRIG bis MITTEL**
+- Polling alle 200ms: vernachlaessigbar (~0.1% CPU)
+- Besser: `SetWinEventHook` eventbasiert — kein Polling noetig
+- Preview-Text-Updates passieren ohnehin alle 1.5s (`preview_interval_sec`) — Monitor-Check dabei mitzumachen ist kostenlos
+- **Empfehlung:** Monitor nur bei `update_text()` neu bestimmen (wie aktuell), NICHT per separatem Polling. Das ist ausreichend fuer die meisten Use-Cases.
+
+### 3.3 Mehrere tkinter-Fenster gleichzeitig ("alle Monitore")
+
+**Risiko: MITTEL bis HOCH**
+- tkinter ist single-threaded — alle N Fenster muessen im selben Thread verwaltet werden
+- `Toplevel()` Fenster sind Standard-tkinter und funktionieren zuverlaessig
+- Potenzielle Probleme:
+  - `overrideredirect(True)` + `topmost` kann sich pro Monitor unterschiedlich verhalten
+  - DPI-Scaling: verschiedene Monitore koennen verschiedene DPI haben — Font-Groesse und Fenster-Groesse muessen pro Monitor angepasst werden
+  - Monitor-Hotplug: Fenster auf abgestecktem Monitor — tkinter gibt keine Events dafuer
+- **Empfehlung:** Toplevel-Fenster bei jedem `update_text()` gegen aktuelle Monitor-Liste abgleichen (Create/Destroy bei Aenderung)
+
+### 3.4 pystray Menu-Tiefe (Submenus)
+
+**Risiko: NIEDRIG**
+- pystray unterstuetzt verschachtelte Submenus problemlos (wird bereits fuer Model/Audio/Listening Mode verwendet)
+- Ein weiteres Submenu "Overlay Monitor" ist kein technisches Problem
+- Dynamische Monitor-Liste analog zur dynamischen Audio-Device-Liste
+- **Einzige Einschraenkung:** pystray-Menus werden bei jedem Zugriff komplett neu erstellt — das ist bereits das bestehende Pattern und funktioniert
+
+### 3.5 Plattform-Kompatibilitaet
+
+**Risiko: MITTEL**
+- `_get_active_monitor()` ist aktuell **rein Windows** (ctypes.windll)
+- `EnumDisplayMonitors` fuer Monitor-Liste ist ebenfalls Windows-only
+- Focus-Follow via `GetForegroundWindow` ist Windows-only
+- **Empfehlung:** Monitor-Funktionalitaet in `platform/` abstrahieren:
+  - `platform/windows/monitors.py` — Win32 API
+  - `platform/macos/monitors.py` — NSScreen API
+  - Oder: `preview_overlay.py` bleibt Windows-only mit Graceful Fallback (wie aktuell)
+
+### 3.6 Monitor-ID Stabilitaet
+
+**Risiko: NIEDRIG**
+- Windows Monitor-Indizes koennen sich bei Plug/Unplug aendern
+- Monitor-Name (z.B. "\\.\DISPLAY1") ist stabiler
+- Config sollte entweder Index + Validierung oder Device-Name speichern
+- Bei ungueltigem Monitor: Fallback auf "auto" (Maus-basiert)
+
+---
+
+## 4. Zusammenfassung der Erweiterungspunkte
+
+| Datei | Was aendern | Aufwand |
+|-------|-------------|---------|
+| `config.defaults.yaml` | `listening.overlay_monitor: "auto"` hinzufuegen | Klein |
+| `config_manager.py` | Getter fuer neuen Key, evtl. Validation | Klein |
+| `preview_overlay.py` | Monitor-Enumeration, Modi (auto/focus/fixed/all), Multi-Window | Gross |
+| `system_tray.py` | "Overlay Monitor" Submenu mit Radiobuttons | Mittel |
+| `state_manager.py` | Handler fuer Monitor-Wechsel, Config-Persistenz | Klein |
+| `platform/windows/` | Optional: Monitor-Enumeration abstrahieren | Mittel |

--- a/doc/agenten/config-designer/config-schema.md
+++ b/doc/agenten/config-designer/config-schema.md
@@ -1,0 +1,340 @@
+# Overlay Config Schema Design
+
+## 1. Config-Schema
+
+### Bestehende Config (listening:)
+
+```yaml
+listening:
+  preview_enabled: false
+  preview_show_tooltip: true
+  preview_show_overlay: false
+```
+
+### Erweiterung
+
+```yaml
+listening:
+  preview_enabled: false
+  preview_show_tooltip: true
+  preview_show_overlay: false
+
+  overlay:
+    # Monitor-Auswahl
+    # "follow_focus" = Overlay erscheint auf dem Monitor mit dem aktiven Fenster
+    # "primary"      = Immer auf dem primaeren Monitor
+    # "all"          = Ein Overlay-Fenster pro Monitor gleichzeitig
+    # 1, 2, 3...     = Fester Monitor (nach Nummer)
+    monitor: follow_focus
+
+    # Position auf dem Monitor
+    # Optionen: bottom_center, top_center, bottom_left, bottom_right,
+    #           top_left, top_right, center
+    position: bottom_center
+
+    # Vertikaler Abstand vom Rand in Pixeln
+    margin: 80
+
+    # Stil
+    font_size: 18
+    opacity: 0.85
+    bg_color: "#1a1a2e"
+    text_color: "#ffffff"
+```
+
+### Warum dieses Schema
+
+- **`monitor`** ist ein Union-Typ: String (`"follow_focus"`, `"primary"`, `"all"`) oder Integer (1, 2, 3...). Damit deckt man alle vier Anwendungsfaelle ab ohne separate Boolean-Flags.
+- **`position`** als Enum statt X/Y-Koordinaten -- einfacher fuer User, und das Overlay berechnet die Pixel-Position selbst basierend auf Monitor-Geometrie.
+- **`margin`** gibt vertikalen Abstand vom Rand -- bei `bottom_center` ist das der Abstand vom unteren Rand, bei `top_center` vom oberen.
+- **Stil-Optionen** sind optional/nice-to-have. Sinnvolle Defaults reichen fuer v1.
+
+### Validierung
+
+| Feld | Typ | Default | Gueltige Werte |
+|------|-----|---------|-----------------|
+| `monitor` | `str \| int` | `"follow_focus"` | `"follow_focus"`, `"primary"`, `"all"`, `1`..`N` |
+| `position` | `str` | `"bottom_center"` | `"bottom_center"`, `"top_center"`, `"bottom_left"`, `"bottom_right"`, `"top_left"`, `"top_right"`, `"center"` |
+| `margin` | `int` | `80` | `0`..`500` |
+| `font_size` | `int` | `18` | `8`..`72` |
+| `opacity` | `float` | `0.85` | `0.1`..`1.0` |
+| `bg_color` | `str` | `"#1a1a2e"` | Hex-Color |
+| `text_color` | `str` | `"#ffffff"` | Hex-Color |
+
+
+---
+
+## 2. Tray-Menu Design
+
+### Bestehende Struktur
+
+```
+Listening Mode ->
+  * Hotkey
+  o Continuous
+  o Wake Word
+[ ] Preview
+---
+Model ->
+Audio Device ->
+...
+Exit
+```
+
+### Erweiterte Struktur
+
+Das "Preview"-Checkbox wird zu einem Submenu mit verschachtelten Optionen:
+
+```
+Listening Mode ->
+  * Hotkey
+  o Continuous
+  o Wake Word
+Preview ->
+  [x] Enabled
+  ---
+  Overlay ->
+    [x] Show Overlay
+    ---
+    Monitor ->
+      * Follow Focus
+      o Primary Monitor
+      o All Monitors
+      ---
+      o Monitor 1 (DELL U2723QE)
+      o Monitor 2 (LG 27UK850)
+    Position ->
+      * Bottom Center
+      o Top Center
+      o Bottom Left
+      o Bottom Right
+---
+```
+
+### Design-Entscheidungen
+
+1. **"Preview" wird Submenu** statt Checkbox -- enthaelt jetzt "Enabled" Toggle + Overlay-Settings.
+2. **Monitor-Namen** werden dynamisch per `screeninfo` oder Win32 API gelesen und angezeigt (z.B. "Monitor 1 (DELL U2723QE)").
+3. **Separator** trennt den generischen Modus (Follow Focus / Primary / All) von den nummerierten Monitoren.
+4. **Position** hat nur die gaengigsten 4 Optionen im Menu (bottom_center, top_center, bottom_left, bottom_right). Weitere per Config-File.
+5. **Stil-Optionen** (font_size, opacity, colors) sind nur per Config-File aenderbar, nicht per Tray -- das wuerde das Menu ueberladen.
+
+### Implementierungs-Hinweise fuer system_tray.py
+
+```python
+# Innerhalb _create_menu():
+
+overlay_config = self.config_manager.get_setting('listening', 'overlay') or {}
+current_monitor = overlay_config.get('monitor', 'follow_focus')
+current_position = overlay_config.get('position', 'bottom_center')
+show_overlay = self.config_manager.get_setting('listening', 'preview_show_overlay')
+
+# Monitor-Submenu
+monitor_choices = [
+    ("Follow Focus", "follow_focus"),
+    ("Primary Monitor", "primary"),
+    ("All Monitors", "all"),
+]
+# + dynamisch: nummerierte Monitore per screeninfo/win32
+
+# Position-Submenu
+position_choices = [
+    ("Bottom Center", "bottom_center"),
+    ("Top Center", "top_center"),
+    ("Bottom Left", "bottom_left"),
+    ("Bottom Right", "bottom_right"),
+]
+```
+
+
+---
+
+## 3. HTTP-Endpoints
+
+### Bestehende Endpoints
+
+```
+GET /mode/preview/on     -> Preview ein
+GET /mode/preview/off    -> Preview aus
+GET /preview             -> Letzter Preview-Text
+```
+
+### Neue Endpoints
+
+```
+GET /overlay                          -> Aktuelle Overlay-Config (JSON)
+GET /overlay/toggle                   -> Overlay ein/aus toggeln
+GET /overlay/monitor/follow_focus     -> Monitor auf follow_focus setzen
+GET /overlay/monitor/primary          -> Monitor auf primary setzen
+GET /overlay/monitor/all              -> Monitor auf all setzen
+GET /overlay/monitor/<N>              -> Monitor auf Nummer N setzen (1, 2, 3...)
+GET /overlay/position/bottom_center   -> Position setzen
+GET /overlay/position/top_center      -> Position setzen
+GET /overlay/position/<position>      -> Position setzen (beliebig)
+```
+
+### Response-Format
+
+**GET /overlay**
+```json
+{
+  "ok": true,
+  "overlay_enabled": true,
+  "monitor": "follow_focus",
+  "position": "bottom_center",
+  "margin": 80,
+  "font_size": 18,
+  "opacity": 0.85,
+  "monitors_available": [
+    {"index": 1, "name": "DELL U2723QE", "primary": true, "width": 3840, "height": 2160},
+    {"index": 2, "name": "LG 27UK850", "primary": false, "width": 3840, "height": 2160}
+  ]
+}
+```
+
+**GET /overlay/monitor/follow_focus** (und alle anderen Setter)
+```json
+{
+  "ok": true,
+  "message": "Monitor set to follow_focus",
+  "monitor": "follow_focus"
+}
+```
+
+### Routing in http_trigger.py
+
+```python
+# In do_GET:
+elif path == "/overlay":
+    self._handle_overlay_config(sm)
+elif path == "/overlay/toggle":
+    self._handle_overlay_toggle(sm)
+elif path.startswith("/overlay/monitor/"):
+    value = path.split("/overlay/monitor/")[1]
+    self._handle_overlay_monitor(sm, value)
+elif path.startswith("/overlay/position/"):
+    value = path.split("/overlay/position/")[1]
+    self._handle_overlay_position(sm, value)
+```
+
+
+---
+
+## 4. Interaktions-Matrix
+
+### Monitor-Modus vs. preview_show_overlay
+
+| `preview_show_overlay` | `overlay.monitor` | Verhalten |
+|------------------------|-------------------|-----------|
+| `false` | (egal) | Kein Overlay. Monitor-Setting wird gespeichert aber ignoriert. |
+| `true` | `follow_focus` | Ein Overlay-Fenster, springt zum Monitor mit aktivem Fenster. Bei Fokuswechsel: altes Overlay schliessen, neues auf Ziel-Monitor oeffnen. |
+| `true` | `primary` | Ein Overlay-Fenster, fest auf dem primaeren Monitor. |
+| `true` | `all` | N Overlay-Fenster gleichzeitig, eins pro erkanntem Monitor. Alle zeigen denselben Text. |
+| `true` | `1`, `2`, `3`... | Ein Overlay-Fenster, fest auf dem Monitor mit der angegebenen Nummer. Fallback auf `primary` wenn Nummer nicht existiert. |
+
+### Preview-States
+
+| `preview_enabled` | `preview_show_overlay` | `preview_show_tooltip` | Ergebnis |
+|--------------------|------------------------|------------------------|----------|
+| `false` | (egal) | (egal) | Kein Preview, kein Overlay, kein Tooltip |
+| `true` | `false` | `true` | Nur Tooltip im Tray |
+| `true` | `true` | `false` | Nur Overlay |
+| `true` | `true` | `true` | Beides: Overlay + Tooltip |
+
+### Edge Cases
+
+1. **Monitor wird abgesteckt waehrend Overlay aktiv**: Overlay auf diesem Monitor schliessen. Bei `follow_focus` oder `all`: automatisch re-layout. Bei fester Nummer: Fallback auf primary.
+2. **Monitor wird angesteckt**: Bei `all`: neues Overlay-Fenster erstellen. Bei fester Nummer: pruefen ob der neue Monitor die gewuenschte Nummer hat.
+3. **follow_focus und kein Fenster fokussiert** (Desktop fokussiert): Overlay auf dem primaeren Monitor anzeigen.
+4. **Ungueltige Monitor-Nummer in Config**: Warnung loggen, Fallback auf `primary`.
+5. **preview_enabled=false wird gesetzt waehrend Overlay sichtbar**: Alle Overlay-Fenster sofort schliessen.
+
+
+---
+
+## 5. config.defaults.yaml Aenderung (Diff)
+
+```yaml
+# Bestehend (unveraendert):
+listening:
+  mode: hotkey
+  preview_enabled: false
+  preview_show_tooltip: true
+  preview_show_overlay: false
+  preview_interval_sec: 1.5
+  preview_max_audio_seconds: 30.0
+  pre_buffer_duration_sec: 0.3
+  post_speech_silence_ms: 800
+  max_speech_duration_sec: 60.0
+  min_speech_duration_sec: 0.5
+
+  # NEU:
+  overlay:
+    monitor: follow_focus
+    position: bottom_center
+    margin: 80
+    font_size: 18
+    opacity: 0.85
+    bg_color: "#1a1a2e"
+    text_color: "#ffffff"
+```
+
+
+---
+
+## 6. StateManager Aenderungen (Skizze)
+
+Neue Felder und Methoden fuer `state_manager.py`:
+
+```python
+# __init__:
+overlay_config = listening_config.get('overlay', {})
+self.overlay_monitor = overlay_config.get('monitor', 'follow_focus')
+self.overlay_position = overlay_config.get('position', 'bottom_center')
+
+# Neue Methoden:
+def set_overlay_monitor(self, value: str | int):
+    self.overlay_monitor = value
+    self.config_manager.update_user_setting('listening', 'overlay', 'monitor', value)
+    if self.preview_overlay:
+        self.preview_overlay.reconfigure(monitor=value)
+
+def set_overlay_position(self, value: str):
+    self.overlay_position = value
+    self.config_manager.update_user_setting('listening', 'overlay', 'position', value)
+    if self.preview_overlay:
+        self.preview_overlay.reconfigure(position=value)
+
+def get_overlay_config(self) -> dict:
+    overlay = self.config_manager.get_setting('listening', 'overlay') or {}
+    return {
+        "overlay_enabled": self.preview_show_overlay,
+        "monitor": overlay.get('monitor', 'follow_focus'),
+        "position": overlay.get('position', 'bottom_center'),
+        "margin": overlay.get('margin', 80),
+        "font_size": overlay.get('font_size', 18),
+        "opacity": overlay.get('opacity', 0.85),
+    }
+
+# Erweiterung von get_mode_info:
+def get_mode_info(self) -> dict:
+    return {
+        "mode": self.listening_mode.value,
+        "preview": self.preview_enabled,
+        "overlay": self.preview_show_overlay,
+        "overlay_monitor": self.overlay_monitor,
+    }
+```
+
+
+---
+
+## 7. Zusammenfassung der Aenderungen
+
+| Datei | Aenderung |
+|-------|-----------|
+| `config.defaults.yaml` | `listening.overlay` Block hinzufuegen |
+| `state_manager.py` | `overlay_monitor`, `overlay_position` Felder + Setter/Getter |
+| `system_tray.py` | Preview Checkbox -> Submenu mit Overlay/Monitor/Position |
+| `http_trigger.py` | `/overlay/*` Endpoints |
+| `config_manager.py` | Validierung fuer `listening.overlay.*` Felder |

--- a/doc/agenten/win32-researcher/ergebnisse.md
+++ b/doc/agenten/win32-researcher/ergebnisse.md
@@ -1,0 +1,630 @@
+# Win32 Multi-Monitor API Research
+
+## 1. Multi-Monitor APIs (Win32 via ctypes)
+
+### 1.1 EnumDisplayMonitors — Alle Monitore auflisten
+
+Enumeriert alle Display-Monitore und ruft einen Callback pro Monitor auf.
+
+```python
+import ctypes
+import ctypes.wintypes as wintypes
+
+MonitorEnumProc = ctypes.WINFUNCTYPE(
+    wintypes.BOOL, wintypes.HMONITOR, wintypes.HDC,
+    ctypes.POINTER(wintypes.RECT), wintypes.LPARAM
+)
+
+def get_all_monitors():
+    monitors = []
+
+    def callback(hmonitor, hdc, rect, data):
+        r = rect.contents
+        monitors.append({
+            'hmonitor': hmonitor,
+            'left': r.left, 'top': r.top,
+            'right': r.right, 'bottom': r.bottom,
+        })
+        return True  # True = weiter enumerieren
+
+    proc = MonitorEnumProc(callback)
+    ctypes.windll.user32.EnumDisplayMonitors(None, None, proc, 0)
+    return monitors
+```
+
+**Wichtig:** Der `proc`-Callback muss als Variable gehalten werden (nicht inline), sonst wird das ctypes-Trampoline garbage-collected und crasht.
+
+### 1.2 GetMonitorInfoW — Position/Groesse eines Monitors
+
+Liefert `rcMonitor` (volle Flaeche) und `rcWork` (ohne Taskbar) sowie `dwFlags` (MONITORINFOF_PRIMARY = 1).
+
+```python
+class MONITORINFO(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("rcMonitor", wintypes.RECT),
+        ("rcWork", wintypes.RECT),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
+def get_monitor_info(hmonitor):
+    info = MONITORINFO()
+    info.cbSize = ctypes.sizeof(MONITORINFO)
+    ctypes.windll.user32.GetMonitorInfoW(hmonitor, ctypes.byref(info))
+    return info
+```
+
+Fuer den Device-Namen braucht man `MONITORINFOEXW`:
+
+```python
+class MONITORINFOEXW(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("rcMonitor", wintypes.RECT),
+        ("rcWork", wintypes.RECT),
+        ("dwFlags", wintypes.DWORD),
+        ("szDevice", wintypes.WCHAR * 32),
+    ]
+
+def get_monitor_info_ex(hmonitor):
+    info = MONITORINFOEXW()
+    info.cbSize = ctypes.sizeof(MONITORINFOEXW)
+    ctypes.windll.user32.GetMonitorInfoW(hmonitor, ctypes.byref(info))
+    return info  # info.szDevice = z.B. "\\\\.\\DISPLAY1"
+```
+
+### 1.3 MonitorFromPoint — Monitor unter einem Punkt
+
+```python
+MONITOR_DEFAULTTONEAREST = 2
+
+point = wintypes.POINT(x, y)
+hmonitor = ctypes.windll.user32.MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST)
+```
+
+Flags:
+- `MONITOR_DEFAULTTONULL` (0) — gibt NULL wenn kein Monitor
+- `MONITOR_DEFAULTTOPRIMARY` (1) — Fallback auf Primaermonitor
+- `MONITOR_DEFAULTTONEAREST` (2) — naechster Monitor (empfohlen)
+
+### 1.4 MonitorFromWindow — Monitor eines Fensters
+
+```python
+MONITOR_DEFAULTTONEAREST = 2
+
+hwnd = ctypes.windll.user32.GetForegroundWindow()
+hmonitor = ctypes.windll.user32.MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)
+```
+
+Gibt den Monitor zurueck, der die groesste Ueberschneidung mit dem Fenster-Rect hat.
+
+### 1.5 GetForegroundWindow — Aktives Fenster
+
+```python
+hwnd = ctypes.windll.user32.GetForegroundWindow()
+```
+
+Gibt HWND des Fensters zurueck, das aktuell den Eingabefokus hat.
+
+### 1.6 GetWindowRect — Position eines Fensters
+
+```python
+rect = wintypes.RECT()
+ctypes.windll.user32.GetWindowRect(hwnd, ctypes.byref(rect))
+# rect.left, rect.top, rect.right, rect.bottom
+```
+
+### 1.7 Kombination: Monitor des aktuell fokussierten Fensters
+
+```python
+def get_focused_window_monitor():
+    hwnd = ctypes.windll.user32.GetForegroundWindow()
+    if not hwnd:
+        # Kein fokussiertes Fenster -> Fallback auf Cursor-Position
+        point = wintypes.POINT()
+        ctypes.windll.user32.GetCursorPos(ctypes.byref(point))
+        hmonitor = ctypes.windll.user32.MonitorFromPoint(
+            point, MONITOR_DEFAULTTONEAREST
+        )
+    else:
+        hmonitor = ctypes.windll.user32.MonitorFromWindow(
+            hwnd, MONITOR_DEFAULTTONEAREST
+        )
+    info = MONITORINFO()
+    info.cbSize = ctypes.sizeof(MONITORINFO)
+    ctypes.windll.user32.GetMonitorInfoW(hmonitor, ctypes.byref(info))
+    r = info.rcWork  # Arbeitsbereich (ohne Taskbar)
+    return r.left, r.top, r.right - r.left, r.bottom - r.top
+```
+
+---
+
+## 2. tkinter Multi-Monitor
+
+### 2.1 Grundproblem
+
+- `winfo_screenwidth()` / `winfo_screenheight()` geben NUR den Primaermonitor zurueck
+- tkinter hat KEINE eingebaute Multi-Monitor-Erkennung
+- Man MUSS externe APIs (ctypes oder `screeninfo`) nutzen
+
+### 2.2 Positionierung auf bestimmtem Monitor
+
+tkinter nutzt den **Virtual Screen** Koordinatenraum. Fenster werden ueber `geometry()` positioniert:
+
+```python
+# Fenster auf Monitor 2 (rechts vom Primaermonitor) positionieren
+# Wenn Monitor 1 = 1920x1080 bei (0,0), Monitor 2 bei (1920,0):
+root.geometry(f"+{1920 + 100}+{100}")  # x=2020, y=100 -> auf Monitor 2
+
+# Negative Koordinaten fuer Monitor links vom Primaermonitor:
+root.geometry(f"+{-1920 + 100}+{100}")  # Monitor links
+```
+
+### 2.3 Korrekte Positionierung mit Monitor-Info
+
+```python
+def position_on_monitor(window, mon_x, mon_y, mon_w, mon_h):
+    window.update_idletasks()
+    win_w = window.winfo_reqwidth()
+    win_h = window.winfo_reqheight()
+    # Zentriert unten auf dem Monitor
+    x = mon_x + (mon_w - win_w) // 2
+    y = mon_y + mon_h - win_h - 80  # 80px Abstand vom unteren Rand
+    window.geometry(f"+{x}+{y}")
+```
+
+### 2.4 Toplevel fuer mehrere Fenster
+
+```python
+# Ein Tk() pro Applikation, weitere Fenster als Toplevel
+root = tk.Tk()
+root.withdraw()  # Hauptfenster verstecken
+
+# Overlay-Fenster als Toplevel
+overlay = tk.Toplevel(root)
+overlay.overrideredirect(True)
+overlay.attributes("-topmost", True)
+overlay.attributes("-alpha", 0.85)
+overlay.geometry(f"+{mon2_x}+{mon2_y}")
+```
+
+---
+
+## 3. Focus-Follow (Fokuswechsel erkennen)
+
+### 3.1 Polling-Ansatz (einfach)
+
+```python
+import threading
+
+def poll_focus(callback, interval=0.3):
+    last_hwnd = None
+    while True:
+        hwnd = ctypes.windll.user32.GetForegroundWindow()
+        if hwnd != last_hwnd:
+            last_hwnd = hwnd
+            hmonitor = ctypes.windll.user32.MonitorFromWindow(
+                hwnd, MONITOR_DEFAULTTONEAREST
+            )
+            callback(hmonitor)
+        threading.Event().wait(interval)
+```
+
+**Vorteile:** Einfach, keine Abhaengigkeiten, kein Message-Loop noetig.
+**Nachteile:** Leichte Verzoegerung (interval), minimaler CPU-Verbrauch.
+
+### 3.2 Event-basiert: SetWinEventHook (optimal)
+
+```python
+import ctypes
+import ctypes.wintypes as wintypes
+
+EVENT_SYSTEM_FOREGROUND = 0x0003
+EVENT_SYSTEM_MINIMIZEEND = 0x0017
+WINEVENT_OUTOFCONTEXT = 0x0000
+WINEVENT_SKIPOWNPROCESS = 0x0002
+
+WinEventProcType = ctypes.WINFUNCTYPE(
+    None,                    # return: void
+    wintypes.HANDLE,         # hWinEventHook
+    wintypes.DWORD,          # event
+    wintypes.HWND,           # hwnd
+    wintypes.LONG,           # idObject
+    wintypes.LONG,           # idChild
+    wintypes.DWORD,          # idEventThread
+    wintypes.DWORD,          # dwmsEventTime
+)
+
+def start_focus_listener(on_focus_change):
+    """
+    on_focus_change(hwnd) wird aufgerufen wenn ein neues Fenster den Fokus bekommt.
+    MUSS in eigenem Thread laufen (braucht eigenen Message-Loop).
+    """
+    def callback(hWinEventHook, event, hwnd, idObject, idChild,
+                 dwEventThread, dwmsEventTime):
+        if hwnd:
+            on_focus_change(hwnd)
+
+    # WICHTIG: Referenz halten damit der GC den Callback nicht loescht!
+    win_event_proc = WinEventProcType(callback)
+
+    # Hook fuer Fokuswechsel
+    ctypes.windll.user32.SetWinEventHook(
+        EVENT_SYSTEM_FOREGROUND,   # eventMin
+        EVENT_SYSTEM_FOREGROUND,   # eventMax
+        0,                         # hmodWinEventProc (0 = out-of-context)
+        win_event_proc,            # pfnWinEventProc
+        0,                         # idProcess (0 = alle)
+        0,                         # idThread (0 = alle)
+        WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS,
+    )
+
+    # Auch MINIMIZEEND hooken (Foreground-Event wird beim Restore
+    # eines minimierten Fensters NICHT gesendet!)
+    ctypes.windll.user32.SetWinEventHook(
+        EVENT_SYSTEM_MINIMIZEEND,
+        EVENT_SYSTEM_MINIMIZEEND,
+        0,
+        win_event_proc,
+        0, 0,
+        WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS,
+    )
+
+    # Windows Message-Loop (blockiert)
+    msg = wintypes.MSG()
+    while ctypes.windll.user32.GetMessageW(ctypes.byref(msg), 0, 0, 0) != 0:
+        ctypes.windll.user32.TranslateMessage(ctypes.byref(msg))
+        ctypes.windll.user32.DispatchMessageW(ctypes.byref(msg))
+```
+
+**Vorteile:** Sofortige Reaktion, kein Polling, kein CPU-Verbrauch im Leerlauf.
+**Nachteile:** Braucht eigenen Thread mit Message-Loop. Callback-Referenz muss gehalten werden.
+
+### 3.3 Empfehlung
+
+- **Polling** reicht fuer unseren Use-Case (Overlay repositionieren) voellig aus
+- **SetWinEventHook** ist eleganter, braucht aber einen dedizierten Thread mit Message-Loop
+- Fuer ein Overlay das sowieso regelmaessig updated: Polling mit 200-300ms Interval ist optimal
+
+### 3.4 win32-window-monitor Library
+
+```python
+# pip install win32-window-monitor
+from win32_window_monitor import HookEvent, start_event_hook
+
+def on_event(hook_handle, event_id, hwnd, id_object, id_child,
+             event_thread_id, event_time_ms):
+    if event_id == HookEvent.SYSTEM_FOREGROUND:
+        # Neues Fenster hat Fokus
+        pass
+
+start_event_hook(on_event)  # Blockiert (eigener Message-Loop)
+```
+
+---
+
+## 4. Overlay auf ALLEN Monitoren
+
+### 4.1 Virtual Screen Koordinaten
+
+```python
+SM_XVIRTUALSCREEN = 76   # X-Koordinate des Virtual Screen
+SM_YVIRTUALSCREEN = 77   # Y-Koordinate
+SM_CXVIRTUALSCREEN = 78  # Breite
+SM_CYVIRTUALSCREEN = 79  # Hoehe
+SM_CMONITORS = 80        # Anzahl Monitore
+
+vx = ctypes.windll.user32.GetSystemMetrics(SM_XVIRTUALSCREEN)
+vy = ctypes.windll.user32.GetSystemMetrics(SM_YVIRTUALSCREEN)
+vw = ctypes.windll.user32.GetSystemMetrics(SM_CXVIRTUALSCREEN)
+vh = ctypes.windll.user32.GetSystemMetrics(SM_CYVIRTUALSCREEN)
+# vx kann negativ sein wenn ein Monitor links vom Primaermonitor steht
+```
+
+**Achtung:** `GetSystemMetrics` ist NICHT DPI-aware. Fuer korrekte Werte bei verschiedenen DPI-Skalierungen `GetSystemMetricsForDpi()` verwenden oder vorher `SetProcessDpiAwareness(2)` aufrufen.
+
+### 4.2 Ein tkinter-Fenster ueber alle Monitore
+
+```python
+# Gesamten Virtual Screen abdecken
+root.geometry(f"{vw}x{vh}+{vx}+{vy}")
+```
+
+**Problem:** Ein riesiges transparentes Fenster ueber alle Monitore ist Ressourcen-intensiv und kann Input auf allen Monitoren blockieren (auch mit `-alpha`). Nicht empfohlen fuer ein kleines Overlay.
+
+### 4.3 Separates Toplevel pro Monitor (empfohlen)
+
+```python
+def create_overlay_per_monitor(root):
+    overlays = {}
+    monitors = get_all_monitors_with_info()
+
+    for i, mon in enumerate(monitors):
+        overlay = tk.Toplevel(root)
+        overlay.overrideredirect(True)
+        overlay.attributes("-topmost", True)
+        overlay.attributes("-alpha", 0.85)
+        overlay.withdraw()  # Erstmal versteckt
+
+        label = tk.Label(overlay, text="", font=..., fg="#fff", bg="#1e1e1e")
+        label.pack()
+        overlays[i] = (overlay, label, mon)
+
+    return overlays
+```
+
+**Vorteile:**
+- Jedes Overlay ist nur so gross wie noetig
+- Kann gezielt ein-/ausgeblendet werden
+- Kein Input-Blocking auf anderen Monitoren
+- Weniger Ressourcen
+
+**Nachteile:**
+- Mehr Code zum Verwalten
+- Muss bei Monitor-Konfigurationsaenderungen neu erstellt werden
+
+### 4.4 Empfehlung fuer unser Overlay
+
+**Ein einziges Fenster, repositioniert je nach Modus:**
+- "Follow Cursor" -> MonitorFromPoint(GetCursorPos)
+- "Follow Focus" -> MonitorFromWindow(GetForegroundWindow)
+- "Fixed Monitor" -> Fester Monitor aus Config
+- "All Monitors" -> Nicht empfohlen, oder: ein Toplevel pro Monitor
+
+---
+
+## 5. DPI-Awareness
+
+### 5.1 SetProcessDpiAwareness
+
+MUSS frueh aufgerufen werden, BEVOR tkinter oder andere UI-APIs initialisiert werden:
+
+```python
+import ctypes
+
+PROCESS_DPI_UNAWARE = 0
+PROCESS_SYSTEM_DPI_AWARE = 1
+PROCESS_PER_MONITOR_DPI_AWARE = 2
+
+try:
+    ctypes.windll.shcore.SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)
+except Exception:
+    # Windows 8.0 oder aelter - Fallback
+    try:
+        ctypes.windll.user32.SetProcessDPIAware()
+    except Exception:
+        pass
+```
+
+**Wichtig:**
+- Nur ein einziger Aufruf moeglich (danach E_ACCESSDENIED)
+- Wert 2 (PER_MONITOR) noetig damit EnumDisplayMonitors/GetMonitorInfo korrekte Werte bei unterschiedlichen DPI-Skalierungen liefern
+- MUSS vor `tk.Tk()` aufgerufen werden
+- tkinter selbst ruft ggf. `SetProcessDPIAware()` auf (Wert 1) — daher so frueh wie moeglich aufrufen
+
+### 5.2 Auswirkung auf tkinter
+
+Wenn `SetProcessDpiAwareness(2)` gesetzt ist:
+- `winfo_screenwidth/height` gibt physische Pixel zurueck (korrekt)
+- `geometry()` Koordinaten sind in physischen Pixeln
+- Font-Groessen muessen ggf. skaliert werden
+
+Wenn NICHT gesetzt:
+- Windows skaliert das Fenster (kann unscharf sein)
+- `GetMonitorInfo` liefert skalierte (falsche) Werte
+- Overlay kann am falschen Ort landen bei verschiedenen DPI pro Monitor
+
+---
+
+## 6. Python-Libraries (Alternativen zu reinem ctypes)
+
+### 6.1 screeninfo
+
+```
+pip install screeninfo
+```
+
+```python
+from screeninfo import get_monitors
+
+for m in get_monitors():
+    print(f"{m.name}: {m.width}x{m.height} at ({m.x},{m.y}) primary={m.is_primary}")
+```
+
+**Monitor-Attribute:** `x`, `y`, `width`, `height`, `width_mm`, `height_mm`, `name`, `is_primary`
+
+**Vorteile:**
+- Plattformuebergreifend (Windows, macOS, Linux)
+- Einfache API
+- Nutzt intern EnumDisplayMonitors + GetMonitorInfo
+- Setzt `SetProcessDpiAwareness(2)` automatisch
+
+**Nachteile:**
+- Externe Abhaengigkeit
+- Kennt nur statische Monitor-Info (kein Fokus-Tracking)
+- Keine rcWork (Arbeitsbereich ohne Taskbar)
+
+### 6.2 PyGetWindow / PyWinCtl
+
+```
+pip install pygetwindow   # nur Windows
+pip install pywinctl       # plattformuebergreifend
+```
+
+```python
+import pygetwindow as gw
+win = gw.getActiveWindow()
+print(win.title, win.left, win.top, win.width, win.height)
+```
+
+**Kann:** Aktives Fenster finden, Position/Groesse lesen.
+**Kann nicht:** Monitor-Info, Focus-Events.
+
+### 6.3 win32-window-monitor
+
+```
+pip install win32-window-monitor
+```
+
+Wrapper um `SetWinEventHook`. Trackt Fokus-Wechsel mit Callback.
+Siehe Abschnitt 3.4.
+
+### 6.4 pywin32 (win32api)
+
+```
+pip install pywin32
+```
+
+```python
+import win32api
+monitors = win32api.EnumDisplayMonitors()
+for hmon, hdcmon, rect in monitors:
+    info = win32api.GetMonitorInfo(hmon)
+    print(info)
+    # {'Monitor': (0, 0, 1920, 1080), 'Work': (0, 0, 1920, 1040),
+    #  'Flags': 1, 'Device': '\\\\.\\DISPLAY1'}
+```
+
+**Vorteile:** Komfortabler als ctypes, gibt Dicts zurueck.
+**Nachteile:** Grosse Abhaengigkeit (pywin32), nicht plattformuebergreifend.
+
+### 6.5 Empfehlung
+
+**Fuer unser Projekt: Reines ctypes verwenden.**
+- Keine zusaetzliche Abhaengigkeit
+- Wir brauchen nur wenige Funktionen
+- Die aktuelle preview_overlay.py nutzt bereits ctypes
+- Volle Kontrolle ueber DPI-Awareness
+- Alle benoetigten Funktionen in <30 Zeilen implementierbar
+
+---
+
+## 7. Komplettes Referenz-Beispiel: Monitor-Utility
+
+```python
+import ctypes
+import ctypes.wintypes as wintypes
+
+MONITOR_DEFAULTTONEAREST = 2
+SM_CMONITORS = 80
+
+class MONITORINFO(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("rcMonitor", wintypes.RECT),
+        ("rcWork", wintypes.RECT),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
+MonitorEnumProc = ctypes.WINFUNCTYPE(
+    wintypes.BOOL, wintypes.HMONITOR, wintypes.HDC,
+    ctypes.POINTER(wintypes.RECT), wintypes.LPARAM,
+)
+
+user32 = ctypes.windll.user32
+
+
+def set_dpi_aware():
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)
+    except Exception:
+        try:
+            user32.SetProcessDPIAware()
+        except Exception:
+            pass
+
+
+def enumerate_monitors():
+    """Alle Monitore mit Work-Area (ohne Taskbar) zurueckgeben."""
+    results = []
+
+    def callback(hmonitor, hdc, rect, data):
+        info = MONITORINFO()
+        info.cbSize = ctypes.sizeof(MONITORINFO)
+        user32.GetMonitorInfoW(hmonitor, ctypes.byref(info))
+        r = info.rcWork
+        results.append({
+            'hmonitor': hmonitor,
+            'x': r.left,
+            'y': r.top,
+            'w': r.right - r.left,
+            'h': r.bottom - r.top,
+            'is_primary': bool(info.dwFlags & 1),
+        })
+        return True
+
+    proc = MonitorEnumProc(callback)
+    user32.EnumDisplayMonitors(None, None, proc, 0)
+    return results
+
+
+def get_monitor_count():
+    return user32.GetSystemMetrics(SM_CMONITORS)
+
+
+def get_cursor_monitor():
+    """Monitor unter der aktuellen Mausposition."""
+    point = wintypes.POINT()
+    user32.GetCursorPos(ctypes.byref(point))
+    hmon = user32.MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST)
+    info = MONITORINFO()
+    info.cbSize = ctypes.sizeof(MONITORINFO)
+    user32.GetMonitorInfoW(hmon, ctypes.byref(info))
+    r = info.rcWork
+    return r.left, r.top, r.right - r.left, r.bottom - r.top
+
+
+def get_focused_window_monitor():
+    """Monitor des aktuell fokussierten Fensters."""
+    hwnd = user32.GetForegroundWindow()
+    if not hwnd:
+        return get_cursor_monitor()
+    hmon = user32.MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)
+    info = MONITORINFO()
+    info.cbSize = ctypes.sizeof(MONITORINFO)
+    user32.GetMonitorInfoW(hmon, ctypes.byref(info))
+    r = info.rcWork
+    return r.left, r.top, r.right - r.left, r.bottom - r.top
+
+
+def get_monitor_by_index(index):
+    """Monitor nach Index (0-basiert, sortiert links->rechts)."""
+    monitors = enumerate_monitors()
+    monitors.sort(key=lambda m: (m['x'], m['y']))
+    if 0 <= index < len(monitors):
+        m = monitors[index]
+        return m['x'], m['y'], m['w'], m['h']
+    return get_cursor_monitor()  # Fallback
+```
+
+---
+
+## 8. Zusammenfassung fuer die Implementierung
+
+| Feature | API | Aufwand |
+|---------|-----|---------|
+| Alle Monitore auflisten | `EnumDisplayMonitors` + `GetMonitorInfoW` | Klein |
+| Monitor unter Cursor | `GetCursorPos` + `MonitorFromPoint` | Bereits implementiert |
+| Monitor des aktiven Fensters | `GetForegroundWindow` + `MonitorFromWindow` | Klein |
+| Fester Monitor (Config) | `EnumDisplayMonitors` + Index | Klein |
+| Fokus-Follow (Event) | `SetWinEventHook` + Message-Loop | Mittel |
+| Fokus-Follow (Polling) | `GetForegroundWindow` in Timer | Klein |
+| DPI-Awareness | `SetProcessDpiAwareness(2)` | Einzeiler, aber frueh |
+| Overlay repositionieren | `tkinter.geometry("+x+y")` | Bereits implementiert |
+
+### Empfohlene Konfigurationsoptionen
+
+```yaml
+overlay:
+  monitor: "cursor"         # "cursor" | "focus" | 0 | 1 | 2 ...
+  position: "bottom_center" # "bottom_center" | "top_center" | "center"
+  offset_y: -80             # Pixel-Offset vom berechneten Punkt
+```
+
+### Prioritaet
+
+1. `SetProcessDpiAwareness(2)` einbauen (frueh in main.py)
+2. `get_focused_window_monitor()` als Alternative zu `get_cursor_monitor()`
+3. `enumerate_monitors()` + Index fuer feste Monitor-Zuweisung
+4. Config-Option `overlay.monitor` mit den drei Modi
+5. Optional: Polling-Timer der bei Fokuswechsel das Overlay repositioniert

--- a/doc/backlog/implementation-log.md
+++ b/doc/backlog/implementation-log.md
@@ -5,7 +5,8 @@
 
 ### Phase 0: Listening Mode System — DONE (dcc1b05)
 - 7 Dateien modifiziert, ListeningMode Enum, HTTP /mode/*, CLI --mode/--preview, Tray Radiobuttons
-### Phase 1: Audio-Stream Refactoring — PENDING
+### Phase 1: Audio-Stream Refactoring — DONE (c6b46db)
+- Neue audio_stream.py (AudioStreamManager), audio_recorder.py refactored, state_manager vereinfacht
 ### Phase 2: Continuous Listening — PENDING
 ### Phase 3: Realtime Preview — PENDING
 ### Phase 4: Wake Word Detection — PENDING

--- a/doc/backlog/implementation-log.md
+++ b/doc/backlog/implementation-log.md
@@ -1,0 +1,10 @@
+# Implementation Log
+
+## Branch: feature/vad-realtime-wakeword
+## Basis: local_master (7625b56)
+
+### Phase 0: Listening Mode System — PENDING
+### Phase 1: Audio-Stream Refactoring — PENDING
+### Phase 2: Continuous Listening — PENDING
+### Phase 3: Realtime Preview — PENDING
+### Phase 4: Wake Word Detection — PENDING

--- a/doc/backlog/implementation-log.md
+++ b/doc/backlog/implementation-log.md
@@ -7,6 +7,8 @@
 - 7 Dateien modifiziert, ListeningMode Enum, HTTP /mode/*, CLI --mode/--preview, Tray Radiobuttons
 ### Phase 1: Audio-Stream Refactoring — DONE (c6b46db)
 - Neue audio_stream.py (AudioStreamManager), audio_recorder.py refactored, state_manager vereinfacht
-### Phase 2: Continuous Listening — PENDING
-### Phase 3: Realtime Preview — PENDING
+### Phase 2+3: Continuous Listening + Realtime Preview — DONE (211162a)
+- continuous_listener.py (VAD state machine, pre-buffer, min/max guards)
+- realtime_preview.py (timer-driven, single-model, transcribe_lock)
+- Integration in StateManager + main.py
 ### Phase 4: Wake Word Detection — PENDING

--- a/doc/backlog/implementation-log.md
+++ b/doc/backlog/implementation-log.md
@@ -11,4 +11,8 @@
 - continuous_listener.py (VAD state machine, pre-buffer, min/max guards)
 - realtime_preview.py (timer-driven, single-model, transcribe_lock)
 - Integration in StateManager + main.py
-### Phase 4: Wake Word Detection — PENDING
+### Phase 4: Wake Word Detection — DONE (a84cc45)
+- wake_word.py (ABC + OpenWakeWord + Porcupine + WakeWordManager)
+- Pre-Wake-VAD, cooldown, graceful degradation, chunk accumulation
+
+## ALLE PHASEN ABGESCHLOSSEN

--- a/doc/backlog/implementation-log.md
+++ b/doc/backlog/implementation-log.md
@@ -3,7 +3,8 @@
 ## Branch: feature/vad-realtime-wakeword
 ## Basis: local_master (7625b56)
 
-### Phase 0: Listening Mode System — PENDING
+### Phase 0: Listening Mode System — DONE (dcc1b05)
+- 7 Dateien modifiziert, ListeningMode Enum, HTTP /mode/*, CLI --mode/--preview, Tray Radiobuttons
 ### Phase 1: Audio-Stream Refactoring — PENDING
 ### Phase 2: Continuous Listening — PENDING
 ### Phase 3: Realtime Preview — PENDING

--- a/src/whisper_key/audio_recorder.py
+++ b/src/whisper_key/audio_recorder.py
@@ -4,38 +4,30 @@ import time
 from typing import Optional, Callable
 
 import numpy as np
-import sounddevice as sd
-import soxr
 
-from .voice_activity_detection import VadEvent, VAD_CHUNK_SIZE
+from .audio_stream import AudioStreamManager, WHISPER_SAMPLE_RATE
+from .voice_activity_detection import VadEvent
+
 
 class AudioRecorder:
-    WHISPER_SAMPLE_RATE = 16000
     THREAD_JOIN_TIMEOUT = 2.0
-    RECORDING_SLEEP_INTERVAL = 100
-    STREAM_DTYPE = np.float32
-    WASAPI_REOPEN_DELAY = 0.05
-       
+
     def __init__(self,
+                 audio_stream_manager: AudioStreamManager,
                  on_vad_event: Callable[[VadEvent], None],
-                 channels: int = 1,
-                 dtype: str = "float32",
                  max_duration: int = 30,
                  on_max_duration_reached: callable = None,
-                 vad_manager = None,
-                 streaming_manager = None,
-                 on_streaming_result: Callable[[str, bool], None] = None,
-                 device = None):
+                 vad_manager=None,
+                 streaming_manager=None,
+                 on_streaming_result: Callable[[str, bool], None] = None):
 
-        self.sample_rate = self.WHISPER_SAMPLE_RATE
-        self.channels = channels
-        self.dtype = dtype
+        self.audio_stream_manager = audio_stream_manager
         self.max_duration = max_duration
         self.on_max_duration_reached = on_max_duration_reached
         self.is_recording = False
         self.audio_data = []
-        self.recording_thread = None
         self.recording_start_time = None
+        self._max_duration_thread = None
         self.logger = logging.getLogger(__name__)
 
         self.vad_manager = vad_manager
@@ -44,105 +36,49 @@ class AudioRecorder:
 
         self.streaming_manager = streaming_manager
         self.on_streaming_result = on_streaming_result
-
-        self.resolve_device(device)
-        self._test_audio_source()
-
         self.continuous_streaming = self._setup_continuous_streaming()
 
     def _setup_continuous_vad_monitoring(self):
         if self.vad_manager.is_available():
-            continuous_vad = self.vad_manager.create_continuous_detector(
+            return self.vad_manager.create_continuous_detector(
                 event_callback=self._handle_vad_event
             )
-            return continuous_vad
-        else:
-            return None
+        return None
 
     def _setup_continuous_streaming(self):
         if self.streaming_manager and self.streaming_manager.is_available():
             continuous_streaming = self.streaming_manager.create_continuous_recognizer(
                 result_callback=self._handle_streaming_result
             )
-            recording_rate = self._get_recording_sample_rate()
+            recording_rate = self.audio_stream_manager.get_recording_sample_rate()
             continuous_streaming.set_recording_rate(recording_rate)
             return continuous_streaming
-        else:
-            return None
+        return None
 
     def _handle_streaming_result(self, text: str, is_final: bool):
         if self.on_streaming_result:
             self.on_streaming_result(text, is_final)
 
-    def resolve_device(self, device):
-        if device == "default" or device is None:
-            self.device = None
-            self._resolve_hostapi(None)
-        elif isinstance(device, int):
-            try:
-                device_info = sd.query_devices(device)
-                if device_info.get('max_input_channels', 0) > 0:
-                    self.device = device
-                    self._resolve_hostapi(device_info)
-                else:
-                    self.logger.warning(f"Selected device {device} has no input channels; using default input instead")
-                    self.device = None
-                    self._resolve_hostapi(None)
-            except Exception as e:
-                self.logger.warning(f"Failed to load device {device}: {e}. Falling back to default input")
-                self.device = None
-                self._resolve_hostapi(None)
-        else:
-            self.logger.warning(f"Invalid device parameter: {device}, using default")
-            self.device = None
-            self._resolve_hostapi(None)
-
-    def _resolve_hostapi(self, device_info):
-        try:
-            if device_info is None:
-                device_info = sd.query_devices(kind='input')
-            hostapi_index = device_info['hostapi']
-            self.device_hostapi = sd.query_hostapis(hostapi_index)['name']
-            self.device_native_rate = int(device_info['default_samplerate'])
-        except Exception as e:
-            self.logger.debug(f"Could not determine host API: {e}")
-            self.device_hostapi = None
-            self.device_native_rate = self.WHISPER_SAMPLE_RATE
-
-    def _needs_resampling(self) -> bool:
-        return self.device_hostapi and 'wasapi' in self.device_hostapi.lower()
-
-    def _get_recording_sample_rate(self) -> int:
-        if self._needs_resampling():
-            return self.device_native_rate
-        return self.WHISPER_SAMPLE_RATE
-
-    def _resample_audio(self, audio: np.ndarray, orig_rate: int, target_rate: int) -> np.ndarray:
-        if orig_rate == target_rate or len(audio) == 0:
-            return audio
-        return soxr.resample(audio.flatten(), orig_rate, target_rate).astype(np.float32)
-
     def _handle_vad_event(self, event: VadEvent):
         self.on_vad_event(event)
 
-    def _wait_for_thread_finish(self):
-        if self.recording_thread:
-            self.recording_thread.join(timeout=self.THREAD_JOIN_TIMEOUT)
-            if self.recording_thread.is_alive():
-                self.logger.warning("Recording thread did not exit within timeout")
-    
-    def _test_audio_source(self):
-        try:
-            if self.device is not None:
-                device_info = sd.query_devices(self.device)
-                self.logger.info(f"Using device: {device_info['name']}")
+    def _on_audio_chunk(self, audio_data):
+        if not self.is_recording:
+            return
+
+        self.audio_data.append(audio_data.copy())
+
+        if self.continuous_vad:
+            needs_resampling = self.audio_stream_manager.needs_resampling()
+            if needs_resampling:
+                chunk_16k = self.audio_stream_manager.resample_to_whisper(audio_data)
+                self.continuous_vad.process_chunk(chunk_16k.reshape(-1, 1))
             else:
-                default_input = sd.query_devices(kind='input')
-                self.logger.info(f"Default source: {default_input['name']}")
-        except Exception as e:
-            self.logger.error(f"Audio source test failed: {e}")
-            raise
-    
+                self.continuous_vad.process_chunk(audio_data)
+
+        if self.continuous_streaming:
+            self.continuous_streaming.process_chunk(audio_data)
+
     def start_recording(self):
         if self.is_recording:
             return False
@@ -159,9 +95,13 @@ class AudioRecorder:
             if self.continuous_streaming:
                 self.continuous_streaming.reset()
 
-            self.recording_thread = threading.Thread(target=self._record_audio)
-            self.recording_thread.daemon = True
-            self.recording_thread.start()
+            self.audio_stream_manager.add_consumer(self._on_audio_chunk)
+
+            if self.max_duration > 0:
+                self._max_duration_thread = threading.Thread(
+                    target=self._monitor_max_duration, daemon=True
+                )
+                self._max_duration_thread.start()
 
             return True
 
@@ -170,16 +110,20 @@ class AudioRecorder:
             print("❌ Failed to start recording!")
             self.is_recording = False
             return False
-    
+
     def stop_recording(self) -> Optional[np.ndarray]:
         if not self.is_recording:
             return None
-        
+
         self.is_recording = False
-        self._wait_for_thread_finish()
-        
+        self.audio_stream_manager.remove_consumer(self._on_audio_chunk)
+
+        if self._max_duration_thread:
+            self._max_duration_thread.join(timeout=self.THREAD_JOIN_TIMEOUT)
+            self._max_duration_thread = None
+
         return self._process_audio_data()
-    
+
     def _process_audio_data(self) -> Optional[np.ndarray]:
         if len(self.audio_data) == 0:
             print("   ✗ No audio data recorded!")
@@ -187,137 +131,50 @@ class AudioRecorder:
 
         audio_array = np.concatenate(self.audio_data, axis=0)
 
-        if self._needs_resampling():
-            recording_rate = self._get_recording_sample_rate()
-            self.logger.info(f"Resampling from {recording_rate} Hz to {self.WHISPER_SAMPLE_RATE} Hz")
-            audio_array = self._resample_audio(audio_array, recording_rate, self.WHISPER_SAMPLE_RATE)
+        if self.audio_stream_manager.needs_resampling():
+            recording_rate = self.audio_stream_manager.get_recording_sample_rate()
+            self.logger.info(f"Resampling from {recording_rate} Hz to {WHISPER_SAMPLE_RATE} Hz")
+            audio_array = self.audio_stream_manager.resample_to_whisper(audio_array)
 
         duration = self.get_audio_duration(audio_array)
         self.logger.info(f"Recorded {duration:.2f} seconds of audio")
         return audio_array
-    
+
     def cancel_recording(self):
         if not self.is_recording:
             return
-        
+
         self.is_recording = False
-        self._wait_for_thread_finish()
-        
+        self.audio_stream_manager.remove_consumer(self._on_audio_chunk)
+
+        if self._max_duration_thread:
+            self._max_duration_thread.join(timeout=self.THREAD_JOIN_TIMEOUT)
+            self._max_duration_thread = None
+
         self.audio_data = []
         self.recording_start_time = None
-    
-    def _record_audio(self):
-        try:
-            recording_rate = self._get_recording_sample_rate()
-            needs_resampling = self._needs_resampling()
 
-            if needs_resampling:
-                vad_blocksize = int(VAD_CHUNK_SIZE * recording_rate / self.WHISPER_SAMPLE_RATE)
-            else:
-                vad_blocksize = VAD_CHUNK_SIZE
+    def _monitor_max_duration(self):
+        while self.is_recording:
+            if self.recording_start_time:
+                elapsed_time = time.time() - self.recording_start_time
+                if elapsed_time >= self.max_duration:
+                    self.logger.info(f"Maximum recording duration of {self.max_duration}s reached")
+                    print(f"⏰ Maximum recording duration of {self.max_duration}s reached - stopping recording")
 
-            def audio_callback(audio_data, frames, _time, status):
-                if self.is_recording:
-                    self.audio_data.append(audio_data.copy())
+                    self.is_recording = False
+                    self.audio_stream_manager.remove_consumer(self._on_audio_chunk)
+                    audio_data = self._process_audio_data()
 
-                    if self.continuous_vad and frames == vad_blocksize:
-                        if needs_resampling:
-                            chunk_16k = self._resample_audio(audio_data, recording_rate, self.WHISPER_SAMPLE_RATE)
-                            self.continuous_vad.process_chunk(chunk_16k.reshape(-1, 1))
-                        else:
-                            self.continuous_vad.process_chunk(audio_data)
+                    if self.on_max_duration_reached:
+                        self.on_max_duration_reached(audio_data)
+                    return
+            time.sleep(0.1)
 
-                    if self.continuous_streaming:
-                        self.continuous_streaming.process_chunk(audio_data)
-
-                if status:
-                    self.logger.debug(f"Audio callback status: {status}")
-
-            blocksize = vad_blocksize if self.continuous_vad else None
-
-            # WASAPI requires delay before reopening stream (OS-level async cleanup)
-            if needs_resampling:
-                time.sleep(self.WASAPI_REOPEN_DELAY)
-
-            with sd.InputStream(samplerate=recording_rate,
-                                channels=self.channels,
-                                callback=audio_callback,
-                                dtype=self.STREAM_DTYPE,
-                                blocksize=blocksize,
-                                device=self.device):
-
-                # NOTE: WASAPI breaks if the calling thread is blocked or if audio
-                # playback runs from this thread. Reason unknown. Don't add synchronization
-                # or audio calls here — print messages before start_recording() returns instead.
-                while self.is_recording:
-                    if self._check_max_duration_exceeded():
-                        break
-
-                    sd.sleep(self.RECORDING_SLEEP_INTERVAL)
-
-        except Exception as e:
-            self.logger.error(f"Error during audio recording: {e}")
-            print(f"❌ Recording failed: {e}")
-            self.is_recording = False
-    
-    def _check_max_duration_exceeded(self) -> bool:
-        if self.max_duration > 0 and self.recording_start_time:
-            elapsed_time = time.time() - self.recording_start_time
-            if elapsed_time >= self.max_duration:
-                self.logger.info(f"Maximum recording duration of {self.max_duration}s reached")
-                print(f"⏰ Maximum recording duration of {self.max_duration}s reached - stopping recording")
-                
-                self.is_recording = False
-                audio_data = self._process_audio_data()
-                
-                if self.on_max_duration_reached:
-                    self.on_max_duration_reached(audio_data)
-                return True
-        return False
-    
     def get_recording_status(self) -> bool:
         return self.is_recording
-    
+
     def get_audio_duration(self, audio_data: np.ndarray) -> float:
         if audio_data is None or len(audio_data) == 0:
             return 0.0
-        return len(audio_data) / self.sample_rate
-
-    def get_device_id(self) -> Optional[int]:
-        if self.device is not None:
-            return self.device
-        default_device_id = sd.query_devices(kind='input')['index']
-        return default_device_id
-
-    @staticmethod
-    def get_available_audio_devices(host_filter: Optional[str] = None):
-        try:
-            all_devices = sd.query_devices()
-            hostapis = sd.query_hostapis()
-        except Exception as e:
-            logging.getLogger(__name__).error(f"Failed to enumerate audio devices: {e}")
-            return []
-
-        devices = []
-        host_filter_lower = host_filter.lower() if host_filter else None
-
-        for idx, device in enumerate(all_devices):
-            if device.get('max_input_channels', 0) <= 0:
-                continue
-
-            hostapi_index = device['hostapi']
-            hostapi_info = hostapis[hostapi_index]
-            hostapi_name = hostapi_info['name']
-
-            if host_filter_lower and hostapi_name.lower() != host_filter_lower:
-                continue
-
-            devices.append({
-                'id': idx,
-                'name': device['name'],
-                'input_channels': device['max_input_channels'],
-                'sample_rate': device['default_samplerate'],
-                'hostapi': hostapi_name
-            })
-
-        return devices
+        return len(audio_data) / WHISPER_SAMPLE_RATE

--- a/src/whisper_key/audio_stream.py
+++ b/src/whisper_key/audio_stream.py
@@ -1,0 +1,199 @@
+import logging
+import threading
+import time
+from typing import Optional, Callable, List
+
+import numpy as np
+import sounddevice as sd
+import soxr
+
+
+WHISPER_SAMPLE_RATE = 16000
+STREAM_CHUNK_SAMPLES = 512
+STREAM_DTYPE = np.float32
+WASAPI_REOPEN_DELAY = 0.05
+
+
+class AudioStreamManager:
+    def __init__(self, device=None):
+        self.logger = logging.getLogger(__name__)
+        self._consumers: List[Callable] = []
+        self._consumers_lock = threading.Lock()
+        self._stream: Optional[sd.InputStream] = None
+        self._running = False
+
+        self.device = None
+        self.device_hostapi = None
+        self.device_native_rate = WHISPER_SAMPLE_RATE
+        self._resolve_device(device)
+
+    def _resolve_device(self, device):
+        if device == "default" or device is None:
+            self.device = None
+            self._resolve_hostapi(None)
+        elif isinstance(device, int):
+            try:
+                device_info = sd.query_devices(device)
+                if device_info.get('max_input_channels', 0) > 0:
+                    self.device = device
+                    self._resolve_hostapi(device_info)
+                else:
+                    self.logger.warning(f"Selected device {device} has no input channels; using default input instead")
+                    self.device = None
+                    self._resolve_hostapi(None)
+            except Exception as e:
+                self.logger.warning(f"Failed to load device {device}: {e}. Falling back to default input")
+                self.device = None
+                self._resolve_hostapi(None)
+        else:
+            self.logger.warning(f"Invalid device parameter: {device}, using default")
+            self.device = None
+            self._resolve_hostapi(None)
+
+    def _resolve_hostapi(self, device_info):
+        try:
+            if device_info is None:
+                device_info = sd.query_devices(kind='input')
+            hostapi_index = device_info['hostapi']
+            self.device_hostapi = sd.query_hostapis(hostapi_index)['name']
+            self.device_native_rate = int(device_info['default_samplerate'])
+        except Exception as e:
+            self.logger.debug(f"Could not determine host API: {e}")
+            self.device_hostapi = None
+            self.device_native_rate = WHISPER_SAMPLE_RATE
+
+    def needs_resampling(self) -> bool:
+        return self.device_hostapi is not None and 'wasapi' in self.device_hostapi.lower()
+
+    def get_recording_sample_rate(self) -> int:
+        if self.needs_resampling():
+            return self.device_native_rate
+        return WHISPER_SAMPLE_RATE
+
+    def resample_to_whisper(self, audio: np.ndarray) -> np.ndarray:
+        orig_rate = self.get_recording_sample_rate()
+        if orig_rate == WHISPER_SAMPLE_RATE or len(audio) == 0:
+            return audio
+        return soxr.resample(audio.flatten(), orig_rate, WHISPER_SAMPLE_RATE).astype(np.float32)
+
+    def add_consumer(self, callback: Callable):
+        with self._consumers_lock:
+            if callback not in self._consumers:
+                self._consumers.append(callback)
+
+    def remove_consumer(self, callback: Callable):
+        with self._consumers_lock:
+            try:
+                self._consumers.remove(callback)
+            except ValueError:
+                pass
+
+    def start(self):
+        if self._running:
+            return
+
+        self._test_audio_source()
+        recording_rate = self.get_recording_sample_rate()
+
+        if self.needs_resampling():
+            blocksize = int(STREAM_CHUNK_SAMPLES * recording_rate / WHISPER_SAMPLE_RATE)
+        else:
+            blocksize = STREAM_CHUNK_SAMPLES
+
+        if self.needs_resampling():
+            time.sleep(WASAPI_REOPEN_DELAY)
+
+        self._stream = sd.InputStream(
+            samplerate=recording_rate,
+            channels=1,
+            callback=self._audio_callback,
+            dtype=STREAM_DTYPE,
+            blocksize=blocksize,
+            device=self.device,
+        )
+        self._stream.start()
+        self._running = True
+        self.logger.info(f"Audio stream started (rate={recording_rate}, device={self.device})")
+
+    def stop(self):
+        if not self._running:
+            return
+
+        self._running = False
+        if self._stream:
+            try:
+                self._stream.stop()
+                self._stream.close()
+            except Exception as e:
+                self.logger.error(f"Error closing audio stream: {e}")
+            self._stream = None
+        self.logger.info("Audio stream stopped")
+
+    def restart_stream(self, device=None):
+        self.stop()
+        if device is not None:
+            self._resolve_device(device)
+        self.start()
+
+    def _audio_callback(self, audio_data, frames, time_info, status):
+        if status:
+            self.logger.debug(f"Audio stream status: {status}")
+
+        with self._consumers_lock:
+            consumers = list(self._consumers)
+
+        for consumer in consumers:
+            try:
+                consumer(audio_data)
+            except Exception as e:
+                self.logger.error(f"Consumer error: {e}")
+
+    def _test_audio_source(self):
+        try:
+            if self.device is not None:
+                device_info = sd.query_devices(self.device)
+                self.logger.info(f"Using device: {device_info['name']}")
+            else:
+                default_input = sd.query_devices(kind='input')
+                self.logger.info(f"Default source: {default_input['name']}")
+        except Exception as e:
+            self.logger.error(f"Audio source test failed: {e}")
+            raise
+
+    def get_device_id(self) -> Optional[int]:
+        if self.device is not None:
+            return self.device
+        return sd.query_devices(kind='input')['index']
+
+    @staticmethod
+    def get_available_audio_devices(host_filter: Optional[str] = None):
+        try:
+            all_devices = sd.query_devices()
+            hostapis = sd.query_hostapis()
+        except Exception as e:
+            logging.getLogger(__name__).error(f"Failed to enumerate audio devices: {e}")
+            return []
+
+        devices = []
+        host_filter_lower = host_filter.lower() if host_filter else None
+
+        for idx, device in enumerate(all_devices):
+            if device.get('max_input_channels', 0) <= 0:
+                continue
+
+            hostapi_index = device['hostapi']
+            hostapi_info = hostapis[hostapi_index]
+            hostapi_name = hostapi_info['name']
+
+            if host_filter_lower and hostapi_name.lower() != host_filter_lower:
+                continue
+
+            devices.append({
+                'id': idx,
+                'name': device['name'],
+                'input_channels': device['max_input_channels'],
+                'sample_rate': device['default_samplerate'],
+                'hostapi': hostapi_name,
+            })
+
+        return devices

--- a/src/whisper_key/commands.defaults.yaml
+++ b/src/whisper_key/commands.defaults.yaml
@@ -54,3 +54,15 @@ commands:
     run: 'snippingtool'
   - trigger: "lock screen"
     run: 'rundll32.exe user32.dll,LockWorkStation'
+
+  # Listening mode commands
+  - trigger: "hotkey mode"
+    run: 'curl -s http://localhost:5757/mode/hotkey'
+  - trigger: "continuous mode"
+    run: 'curl -s http://localhost:5757/mode/continuous'
+  - trigger: "wake word mode"
+    run: 'curl -s http://localhost:5757/mode/wake_word'
+  - trigger: "preview on"
+    run: 'curl -s http://localhost:5757/mode/preview/on'
+  - trigger: "preview off"
+    run: 'curl -s http://localhost:5757/mode/preview/off'

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -351,6 +351,15 @@ listening:
   preview_show_tooltip: true
   preview_show_overlay: false
   preview_interval_sec: 1.5
+
+  overlay:
+    monitor: follow_focus
+    position: bottom_center
+    margin: 80
+    font_size: 18
+    opacity: 0.85
+    bg_color: "#1a1a2e"
+    text_color: "#ffffff"
   preview_max_audio_seconds: 30.0
   pre_buffer_duration_sec: 0.3
   post_speech_silence_ms: 800

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -139,6 +139,8 @@ hotkey: # Hotkey Configuration
   #   - "ctrl+shift+f12"
   recording_hotkey: "ctrl+win | macos: fn+ctrl"
 
+  recording_mode: toggle
+
   # Key to stop recording (shared between transcription and command modes)
   stop_key: "ctrl | macos: fn"
 

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -342,3 +342,13 @@ voice_commands: # Voice Command Settings
   # false = disable voice commands entirely
   # Define commands in commands.yaml (same folder as user_settings.yaml)
   enabled: true
+
+listening:
+  mode: hotkey
+  preview_enabled: false
+  preview_interval_sec: 1.5
+  preview_max_audio_seconds: 30.0
+  pre_buffer_duration_sec: 0.3
+  post_speech_silence_ms: 800
+  max_speech_duration_sec: 60.0
+  min_speech_duration_sec: 0.5

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -352,3 +352,16 @@ listening:
   post_speech_silence_ms: 800
   max_speech_duration_sec: 60.0
   min_speech_duration_sec: 0.5
+
+wake_word:
+  engine: openwakeword
+  cooldown_sec: 2.0
+  vad_pre_filter: true
+  openwakeword:
+    model_paths: []
+    threshold: 0.5
+  porcupine:
+    access_key: ""
+    keyword_paths: []
+    keywords: []
+    sensitivities: []

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -152,11 +152,6 @@ hotkey: # Hotkey Configuration
   # Note: On macOS, ESC is system-reserved
   cancel_combination: "esc | macos: shift"
 
-  # Recording mode
-  # "toggle" = press hotkey to start, press stop key to stop (default)
-  # "push_to_talk" = hold hotkey to record, release to stop and transcribe
-  recording_mode: toggle
-
   # Key combination for voice command mode
   # Records speech and matches against user-defined commands
   command_hotkey: "alt+win | macos: fn+command"
@@ -325,6 +320,20 @@ onboarding: # First-run setup state (managed automatically)
   # Detected GPU class (set automatically)
   # nvidia | amd_rdna2+ | amd_rdna1 | null
   gpu_class: null
+
+http_trigger: # HTTP Trigger API
+
+  # Enable/disable HTTP trigger server
+  # Allows controlling Whisper Key via HTTP requests (e.g. curl localhost:5757/toggle)
+  enabled: true
+
+  # Port number for the HTTP trigger server
+  port: 5757
+
+  # Bind address
+  # "0.0.0.0" = accept connections from any interface
+  # "127.0.0.1" = localhost only (more secure)
+  host: "0.0.0.0"
 
 voice_commands: # Voice Command Settings
 

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -348,6 +348,8 @@ voice_commands: # Voice Command Settings
 listening:
   mode: hotkey
   preview_enabled: false
+  preview_show_tooltip: true
+  preview_show_overlay: false
   preview_interval_sec: 1.5
   preview_max_audio_seconds: 30.0
   pre_buffer_duration_sec: 0.3

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -360,6 +360,7 @@ listening:
     opacity: 0.85
     bg_color: "#1a1a2e"
     text_color: "#ffffff"
+    hide_after_sec: 3.0
   preview_max_audio_seconds: 30.0
   pre_buffer_duration_sec: 0.3
   post_speech_silence_ms: 800

--- a/src/whisper_key/config_manager.py
+++ b/src/whisper_key/config_manager.py
@@ -310,6 +310,15 @@ class ConfigManager:
     def get_streaming_config(self) -> Dict[str, Any]:
         return self.config.get('streaming', {}).copy()
 
+    def get_listening_config(self) -> dict:
+        return self.config.get('listening', {}).copy()
+
+    def update_listening_mode(self, mode: str):
+        self.update_user_setting('listening', 'mode', mode)
+
+    def update_listening_preview(self, enabled: bool):
+        self.update_user_setting('listening', 'preview_enabled', enabled)
+
     def get_log_file_path(self) -> str:
         log_filename = self.config['logging']['file']['filename']
         return os.path.join(get_user_app_data_path(), log_filename)

--- a/src/whisper_key/config_manager.py
+++ b/src/whisper_key/config_manager.py
@@ -313,6 +313,9 @@ class ConfigManager:
     def get_listening_config(self) -> dict:
         return self.config.get('listening', {}).copy()
 
+    def get_wake_word_config(self) -> dict:
+        return self.config.get('wake_word', {}).copy()
+
     def update_listening_mode(self, mode: str):
         self.update_user_setting('listening', 'mode', mode)
 

--- a/src/whisper_key/config_manager.py
+++ b/src/whisper_key/config_manager.py
@@ -316,6 +316,29 @@ class ConfigManager:
     def get_wake_word_config(self) -> dict:
         return self.config.get('wake_word', {}).copy()
 
+    def get_overlay_config(self) -> Dict[str, Any]:
+        defaults = {
+            'monitor': 'follow_focus',
+            'position': 'bottom_center',
+            'margin': 80,
+            'font_size': 18,
+            'opacity': 0.85,
+            'bg_color': '#1a1a2e',
+            'text_color': '#ffffff',
+        }
+        overlay = self.config.get('listening', {}).get('overlay', {})
+        merged = {**defaults, **overlay}
+        return merged
+
+    def update_overlay_setting(self, key: str, value):
+        overlay = self.config.get('listening', {}).get('overlay', {})
+        if overlay.get(key) == value:
+            return
+        overlay[key] = value
+        self.config['listening']['overlay'] = overlay
+        self._save_user_overrides()
+        self.logger.debug(f"Updated overlay setting {key}: {value}")
+
     def update_listening_mode(self, mode: str):
         self.update_user_setting('listening', 'mode', mode)
 

--- a/src/whisper_key/continuous_listener.py
+++ b/src/whisper_key/continuous_listener.py
@@ -1,0 +1,189 @@
+import logging
+import threading
+import time
+from collections import deque
+from enum import Enum
+from typing import Callable, Optional
+
+import numpy as np
+
+from .audio_stream import AudioStreamManager, WHISPER_SAMPLE_RATE, STREAM_CHUNK_SAMPLES
+from .voice_activity_detection import convert_audio_for_ten_vad, VadManager
+
+
+class ListenerState(Enum):
+    IDLE = "idle"
+    SPEECH_ACTIVE = "speech_active"
+    POST_SPEECH = "post_speech"
+
+
+class ContinuousListener:
+    def __init__(self,
+                 audio_stream_manager: AudioStreamManager,
+                 vad_manager: VadManager,
+                 on_speech_audio: Callable[[np.ndarray], None],
+                 is_busy: Callable[[], bool],
+                 pre_buffer_duration_sec: float = 0.3,
+                 post_speech_silence_ms: int = 800,
+                 max_speech_duration_sec: float = 60.0,
+                 min_speech_duration_sec: float = 0.5):
+
+        self.audio_stream_manager = audio_stream_manager
+        self.vad_manager = vad_manager
+        self.on_speech_audio = on_speech_audio
+        self.is_busy = is_busy
+        self.post_speech_silence_ms = post_speech_silence_ms
+        self.max_speech_duration_sec = max_speech_duration_sec
+        self.min_speech_duration_sec = min_speech_duration_sec
+
+        self.logger = logging.getLogger(__name__)
+        self._active = False
+        self._state = ListenerState.IDLE
+
+        chunk_duration_sec = STREAM_CHUNK_SAMPLES / WHISPER_SAMPLE_RATE
+        pre_buffer_chunks = max(1, int(pre_buffer_duration_sec / chunk_duration_sec))
+        self._pre_buffer: deque = deque(maxlen=pre_buffer_chunks)
+
+        self._speech_chunks: list = []
+        self._speech_start_time: Optional[float] = None
+        self._silence_start_time: Optional[float] = None
+
+        self._onset_threshold = vad_manager.vad_onset_threshold
+        self._offset_threshold = vad_manager.vad_offset_threshold
+        self._speech_detected = False
+
+    def _detect_speech(self, probability: float) -> bool:
+        if self._speech_detected:
+            self._speech_detected = probability > self._offset_threshold
+        else:
+            self._speech_detected = probability > self._onset_threshold
+        return self._speech_detected
+
+    def activate(self):
+        if self._active:
+            return
+
+        if not self.vad_manager.is_available():
+            self.logger.warning("Cannot activate continuous listener: VAD not available")
+            return
+
+        self._active = True
+        self._reset_state()
+        self.audio_stream_manager.add_consumer(self._on_audio_chunk)
+        self.logger.info("Continuous listener activated")
+        print("   [CONTINUOUS] listening for speech...")
+
+    def deactivate(self):
+        if not self._active:
+            return
+
+        self._active = False
+        self.audio_stream_manager.remove_consumer(self._on_audio_chunk)
+        self._reset_state()
+        self.logger.info("Continuous listener deactivated")
+
+    def _reset_state(self):
+        self._state = ListenerState.IDLE
+        self._pre_buffer.clear()
+        self._speech_chunks = []
+        self._speech_start_time = None
+        self._silence_start_time = None
+        self._speech_detected = False
+
+    def _get_vad_probability(self, audio_chunk: np.ndarray) -> Optional[float]:
+        try:
+            if self.audio_stream_manager.needs_resampling():
+                chunk_16k = self.audio_stream_manager.resample_to_whisper(audio_chunk)
+            else:
+                chunk_16k = audio_chunk
+
+            audio_int16 = convert_audio_for_ten_vad(chunk_16k)
+            probability, _ = self.vad_manager.ten_vad.process(audio_int16)
+            return probability
+        except Exception as e:
+            self.logger.error(f"VAD processing error: {e}")
+            return None
+
+    def _on_audio_chunk(self, audio_data):
+        if not self._active:
+            return
+
+        if self.is_busy():
+            if self._state != ListenerState.IDLE:
+                self._reset_state()
+            return
+
+        chunk = audio_data.copy()
+        probability = self._get_vad_probability(chunk)
+        if probability is None:
+            return
+
+        is_speech = self._detect_speech(probability)
+        now = time.time()
+
+        if self._state == ListenerState.IDLE:
+            self._pre_buffer.append(chunk)
+            if is_speech:
+                self._transition_to_speech(now)
+
+        elif self._state == ListenerState.SPEECH_ACTIVE:
+            self._speech_chunks.append(chunk)
+            if not is_speech:
+                self._state = ListenerState.POST_SPEECH
+                self._silence_start_time = now
+            elif now - self._speech_start_time >= self.max_speech_duration_sec:
+                self.logger.info(f"Max speech duration ({self.max_speech_duration_sec}s) reached")
+                self._finalize_speech()
+
+        elif self._state == ListenerState.POST_SPEECH:
+            self._speech_chunks.append(chunk)
+            if is_speech:
+                self._state = ListenerState.SPEECH_ACTIVE
+                self._silence_start_time = None
+            else:
+                silence_elapsed_ms = (now - self._silence_start_time) * 1000
+                if silence_elapsed_ms >= self.post_speech_silence_ms:
+                    self._finalize_speech()
+
+    def _transition_to_speech(self, now: float):
+        self._state = ListenerState.SPEECH_ACTIVE
+        self._speech_start_time = now
+        self._silence_start_time = None
+        self._speech_chunks = list(self._pre_buffer)
+        self._pre_buffer.clear()
+        self.logger.info("Continuous listener: speech started")
+
+    def _finalize_speech(self):
+        speech_chunks = self._speech_chunks
+
+        self._state = ListenerState.IDLE
+        self._speech_chunks = []
+        self._speech_start_time = None
+        self._silence_start_time = None
+        self._speech_detected = False
+
+        if not speech_chunks:
+            return
+
+        audio_array = np.concatenate(speech_chunks, axis=0)
+
+        if self.audio_stream_manager.needs_resampling():
+            audio_array = self.audio_stream_manager.resample_to_whisper(audio_array)
+
+        duration = len(audio_array) / WHISPER_SAMPLE_RATE
+
+        if duration < self.min_speech_duration_sec:
+            self.logger.info(f"Discarding short speech segment ({duration:.2f}s < {self.min_speech_duration_sec}s)")
+            return
+
+        self.logger.info(f"Continuous listener: speech segment {duration:.2f}s")
+        print(f"\n🎙️ Speech detected ({duration:.1f}s), transcribing...")
+        threading.Thread(target=self.on_speech_audio, args=(audio_array,), daemon=True).start()
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    @property
+    def state(self) -> ListenerState:
+        return self._state

--- a/src/whisper_key/http_trigger.py
+++ b/src/whisper_key/http_trigger.py
@@ -64,6 +64,8 @@ class _TriggerHandler(BaseHTTPRequestHandler):
             self._handle_set_preview(sm, True)
         elif path == "/mode/preview/off":
             self._handle_set_preview(sm, False)
+        elif path == "/preview":
+            self._handle_preview(sm)
         else:
             self._error(404, f"Unknown endpoint: {path}")
 
@@ -132,6 +134,10 @@ class _TriggerHandler(BaseHTTPRequestHandler):
         sm.set_preview_enabled(enabled)
         mode_info = sm.get_mode_info()
         self._json_response(200, {"ok": True, **mode_info})
+
+    def _handle_preview(self, sm):
+        preview = sm.get_last_preview_text()
+        self._json_response(200, {"ok": True, **preview})
 
 
 class HttpTrigger:

--- a/src/whisper_key/http_trigger.py
+++ b/src/whisper_key/http_trigger.py
@@ -66,6 +66,16 @@ class _TriggerHandler(BaseHTTPRequestHandler):
             self._handle_set_preview(sm, False)
         elif path == "/preview":
             self._handle_preview(sm)
+        elif path == "/overlay":
+            self._handle_overlay_config(sm)
+        elif path == "/overlay/toggle":
+            self._handle_overlay_toggle(sm)
+        elif path.startswith("/overlay/monitor/"):
+            value = path.split("/overlay/monitor/", 1)[1]
+            self._handle_overlay_monitor(sm, value)
+        elif path.startswith("/overlay/position/"):
+            value = path.split("/overlay/position/", 1)[1]
+            self._handle_overlay_position(sm, value)
         else:
             self._error(404, f"Unknown endpoint: {path}")
 
@@ -138,6 +148,54 @@ class _TriggerHandler(BaseHTTPRequestHandler):
     def _handle_preview(self, sm):
         preview = sm.get_last_preview_text()
         self._json_response(200, {"ok": True, **preview})
+
+    def _handle_overlay_config(self, sm):
+        config = sm.get_overlay_config()
+        try:
+            from .platform import monitors
+            available = []
+            for m in monitors.enumerate_monitors():
+                available.append({
+                    "index": m.index, "name": m.name,
+                    "primary": m.is_primary,
+                    "width": m.width, "height": m.height,
+                })
+            config["monitors_available"] = available
+        except Exception:
+            config["monitors_available"] = []
+        self._json_response(200, {"ok": True, **config})
+
+    def _handle_overlay_toggle(self, sm):
+        new_state = not sm.preview_show_overlay
+        sm.set_overlay_enabled(new_state)
+        sm.system_tray.refresh_menu()
+        self._ok(f"Overlay {'enabled' if new_state else 'disabled'}", overlay=new_state)
+
+    def _handle_overlay_monitor(self, sm, value: str):
+        VALID_NAMES = {"follow_focus", "cursor", "primary", "all"}
+        if value in VALID_NAMES:
+            monitor_value = value
+        else:
+            try:
+                monitor_value = int(value)
+            except ValueError:
+                self._error(400, f"Invalid monitor value: {value}")
+                return
+        sm.set_overlay_monitor(monitor_value)
+        sm.system_tray.refresh_menu()
+        self._ok(f"Monitor set to {monitor_value}", monitor=monitor_value)
+
+    def _handle_overlay_position(self, sm, value: str):
+        VALID_POSITIONS = {
+            "bottom_center", "top_center", "bottom_left", "bottom_right",
+            "top_left", "top_right", "center",
+        }
+        if value not in VALID_POSITIONS:
+            self._error(400, f"Invalid position: {value}")
+            return
+        sm.set_overlay_position(value)
+        sm.system_tray.refresh_menu()
+        self._ok(f"Position set to {value}", position=value)
 
 
 class HttpTrigger:

--- a/src/whisper_key/http_trigger.py
+++ b/src/whisper_key/http_trigger.py
@@ -1,20 +1,9 @@
-"""
-HTTP Trigger for Whisper Key
-Provides a simple HTTP API to control recording via the StateManager.
-
-Endpoints:
-    GET /record   - Start recording
-    GET /stop     - Stop recording (transcribe + clipboard)
-    GET /toggle   - Toggle recording (start if idle, stop if recording)
-    GET /cancel   - Cancel active recording
-    GET /command  - Start voice command recording
-    GET /status   - Get current state (idle/recording/processing/model_loading)
-"""
-
 import json
 import logging
 import threading
 from http.server import HTTPServer, BaseHTTPRequestHandler
+
+from .state_manager import ListeningMode
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +52,18 @@ class _TriggerHandler(BaseHTTPRequestHandler):
             self._handle_command(sm)
         elif path == "/status":
             self._handle_status(sm)
+        elif path == "/mode":
+            self._handle_mode_info(sm)
+        elif path == "/mode/hotkey":
+            self._handle_set_mode(sm, ListeningMode.HOTKEY)
+        elif path == "/mode/continuous":
+            self._handle_set_mode(sm, ListeningMode.CONTINUOUS)
+        elif path == "/mode/wake_word":
+            self._handle_set_mode(sm, ListeningMode.WAKE_WORD)
+        elif path == "/mode/preview/on":
+            self._handle_set_preview(sm, True)
+        elif path == "/mode/preview/off":
+            self._handle_set_preview(sm, False)
         else:
             self._error(404, f"Unknown endpoint: {path}")
 
@@ -115,7 +116,22 @@ class _TriggerHandler(BaseHTTPRequestHandler):
 
     def _handle_status(self, sm):
         state = sm.get_current_state()
-        self._ok(state, state=state)
+        mode_info = sm.get_mode_info()
+        self._ok(state, state=state, **mode_info)
+
+    def _handle_mode_info(self, sm):
+        mode_info = sm.get_mode_info()
+        self._json_response(200, {"ok": True, **mode_info})
+
+    def _handle_set_mode(self, sm, mode: ListeningMode):
+        sm.set_listening_mode(mode)
+        mode_info = sm.get_mode_info()
+        self._json_response(200, {"ok": True, **mode_info})
+
+    def _handle_set_preview(self, sm, enabled: bool):
+        sm.set_preview_enabled(enabled)
+        mode_info = sm.get_mode_info()
+        self._json_response(200, {"ok": True, **mode_info})
 
 
 class HttpTrigger:

--- a/src/whisper_key/http_trigger.py
+++ b/src/whisper_key/http_trigger.py
@@ -181,9 +181,12 @@ class _TriggerHandler(BaseHTTPRequestHandler):
             except ValueError:
                 self._error(400, f"Invalid monitor value: {value}")
                 return
-        sm.set_overlay_monitor(monitor_value)
-        sm.system_tray.refresh_menu()
-        self._ok(f"Monitor set to {monitor_value}", monitor=monitor_value)
+        try:
+            sm.set_overlay_monitor(monitor_value)
+            sm.system_tray.refresh_menu()
+        except Exception as e:
+            logger.warning(f"Overlay monitor update: {e}")
+        self._ok(f"Monitor set to {monitor_value}", monitor=str(monitor_value))
 
     def _handle_overlay_position(self, sm, value: str):
         VALID_POSITIONS = {
@@ -193,8 +196,11 @@ class _TriggerHandler(BaseHTTPRequestHandler):
         if value not in VALID_POSITIONS:
             self._error(400, f"Invalid position: {value}")
             return
-        sm.set_overlay_position(value)
-        sm.system_tray.refresh_menu()
+        try:
+            sm.set_overlay_position(value)
+            sm.system_tray.refresh_menu()
+        except Exception as e:
+            logger.warning(f"Overlay position update: {e}")
         self._ok(f"Position set to {value}", position=value)
 
 

--- a/src/whisper_key/http_trigger.py
+++ b/src/whisper_key/http_trigger.py
@@ -1,0 +1,147 @@
+"""
+HTTP Trigger for Whisper Key
+Provides a simple HTTP API to control recording via the StateManager.
+
+Endpoints:
+    GET /record   - Start recording
+    GET /stop     - Stop recording (transcribe + clipboard)
+    GET /toggle   - Toggle recording (start if idle, stop if recording)
+    GET /cancel   - Cancel active recording
+    GET /command  - Start voice command recording
+    GET /status   - Get current state (idle/recording/processing/model_loading)
+"""
+
+import json
+import logging
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+logger = logging.getLogger(__name__)
+
+
+class _TriggerHandler(BaseHTTPRequestHandler):
+    """Handles incoming HTTP requests and dispatches to the StateManager."""
+
+    # Suppress default request logging (we log ourselves)
+    def log_message(self, format, *args):
+        logger.debug("HTTP %s", format % args)
+
+    # ---- helpers ----------------------------------------------------------
+
+    def _json_response(self, status_code: int, data: dict):
+        payload = json.dumps(data).encode("utf-8")
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _ok(self, message: str, **extra):
+        body = {"ok": True, "message": message}
+        body.update(extra)
+        self._json_response(200, body)
+
+    def _error(self, status_code: int, message: str):
+        self._json_response(status_code, {"ok": False, "error": message})
+
+    # ---- routing ----------------------------------------------------------
+
+    def do_GET(self):  # noqa: N802
+        path = self.path.split("?")[0].rstrip("/")
+        sm = self.server.state_manager  # type: ignore[attr-defined]
+
+        if path == "/record":
+            self._handle_record(sm)
+        elif path == "/stop":
+            self._handle_stop(sm)
+        elif path == "/toggle":
+            self._handle_toggle(sm)
+        elif path == "/cancel":
+            self._handle_cancel(sm)
+        elif path == "/command":
+            self._handle_command(sm)
+        elif path == "/status":
+            self._handle_status(sm)
+        else:
+            self._error(404, f"Unknown endpoint: {path}")
+
+    # ---- endpoint handlers ------------------------------------------------
+
+    def _handle_record(self, sm):
+        state = sm.get_current_state()
+        if state != "idle":
+            self._error(409, f"Cannot start recording while {state}")
+            return
+        sm.start_recording()
+        self._ok("Recording started")
+
+    def _handle_stop(self, sm):
+        state = sm.get_current_state()
+        if state != "recording":
+            self._error(409, f"Not recording (current state: {state})")
+            return
+        sm.stop_recording()
+        text = sm.last_transcription or ""
+        self._ok("Transcription complete", text=text, action="stop")
+
+    def _handle_toggle(self, sm):
+        state = sm.get_current_state()
+        if state == "idle":
+            sm.start_recording()
+            self._ok("Recording started", action="record")
+        elif state == "recording":
+            sm.stop_recording()
+            text = sm.last_transcription or ""
+            self._ok("Transcription complete", text=text, action="stop")
+        else:
+            self._error(409, f"Cannot toggle while {state}")
+
+    def _handle_cancel(self, sm):
+        state = sm.get_current_state()
+        if state == "recording":
+            sm.cancel_active_recording()
+            self._ok("Recording cancelled")
+        else:
+            self._error(409, f"Nothing to cancel (current state: {state})")
+
+    def _handle_command(self, sm):
+        state = sm.get_current_state()
+        if state != "idle":
+            self._error(409, f"Cannot start command recording while {state}")
+            return
+        sm.start_command_recording()
+        self._ok("Command recording started")
+
+    def _handle_status(self, sm):
+        state = sm.get_current_state()
+        self._ok(state, state=state)
+
+
+class HttpTrigger:
+    """Runs a lightweight HTTP server in a daemon thread to control Whisper Key."""
+
+    def __init__(self, state_manager, host: str = "0.0.0.0", port: int = 5757):
+        self.state_manager = state_manager
+        self.host = host
+        self.port = port
+        self._server = None
+        self._thread = None
+
+    def start(self):
+        self._server = HTTPServer((self.host, self.port), _TriggerHandler)
+        # Attach state_manager so the handler can reach it via self.server
+        self._server.state_manager = self.state_manager  # type: ignore[attr-defined]
+
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="http-trigger",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("HTTP trigger listening on %s:%d", self.host, self.port)
+
+    def stop(self):
+        if self._server:
+            self._server.shutdown()
+            logger.info("HTTP trigger stopped")

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -16,6 +16,7 @@ sys.stdout.flush()
 
 from .platform import app, permissions
 from .config_manager import ConfigManager
+from .audio_stream import AudioStreamManager
 from .audio_recorder import AudioRecorder
 from .hotkey_listener import HotkeyListener
 from .whisper_engine import WhisperEngine
@@ -70,17 +71,15 @@ def setup_exception_handler():
     
     sys.excepthook = exception_handler
 
-def setup_audio_recorder(audio_config, state_manager, vad_manager, streaming_manager):
+def setup_audio_recorder(audio_config, audio_stream_manager, state_manager, vad_manager, streaming_manager):
     return AudioRecorder(
-        channels=audio_config['channels'],
-        dtype=audio_config['dtype'],
+        audio_stream_manager=audio_stream_manager,
         max_duration=audio_config['max_duration'],
         on_max_duration_reached=state_manager.handle_max_recording_duration_reached,
         on_vad_event=state_manager.handle_vad_event,
         vad_manager=vad_manager,
         streaming_manager=streaming_manager,
         on_streaming_result=state_manager.handle_streaming_result,
-        device=audio_config['input_device']
     )
 
 def setup_vad(vad_config):
@@ -246,6 +245,8 @@ def main():
         audio_feedback = setup_audio_feedback(audio_feedback_config)
         voice_command_manager = setup_voice_commands(voice_commands_config, clipboard_manager, log_transcriptions)
 
+        audio_stream_manager = AudioStreamManager(device=audio_config['input_device'])
+
         state_manager = StateManager(
             audio_recorder=None,
             whisper_engine=whisper_engine,
@@ -254,9 +255,10 @@ def main():
             config_manager=config_manager,
             audio_feedback=audio_feedback,
             vad_manager=vad_manager,
-            voice_command_manager=voice_command_manager
+            voice_command_manager=voice_command_manager,
+            audio_stream_manager=audio_stream_manager,
         )
-        audio_recorder = setup_audio_recorder(audio_config, state_manager, vad_manager, streaming_manager)
+        audio_recorder = setup_audio_recorder(audio_config, audio_stream_manager, state_manager, vad_manager, streaming_manager)
         system_tray = setup_system_tray(tray_config, config_manager, state_manager, model_registry)
         state_manager.attach_components(audio_recorder, system_tray)
 
@@ -288,6 +290,8 @@ def main():
                     app.run_event_loop(shutdown_event)
                     return
                 clipboard_manager.update_auto_paste(False)
+
+        audio_stream_manager.start()
 
         print("🚀 Whisper Key ready!")
         config_manager.print_startup_hotkey_instructions()

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -23,6 +23,8 @@ from .whisper_engine import WhisperEngine
 from .voice_activity_detection import VadManager
 from .clipboard_manager import ClipboardManager
 from .state_manager import StateManager, ListeningMode
+from .continuous_listener import ContinuousListener
+from .realtime_preview import RealtimePreview
 from .system_tray import SystemTray
 from .audio_feedback import AudioFeedback
 from .instance_manager import guard_against_multiple_instances
@@ -246,6 +248,7 @@ def main():
         voice_command_manager = setup_voice_commands(voice_commands_config, clipboard_manager, log_transcriptions)
 
         audio_stream_manager = AudioStreamManager(device=audio_config['input_device'])
+        listening_config = config_manager.get_listening_config()
 
         state_manager = StateManager(
             audio_recorder=None,
@@ -258,6 +261,28 @@ def main():
             voice_command_manager=voice_command_manager,
             audio_stream_manager=audio_stream_manager,
         )
+
+        continuous_listener = ContinuousListener(
+            audio_stream_manager=audio_stream_manager,
+            vad_manager=vad_manager,
+            on_speech_audio=state_manager.handle_continuous_audio,
+            is_busy=state_manager.is_busy,
+            pre_buffer_duration_sec=listening_config.get('pre_buffer_duration_sec', 0.3),
+            post_speech_silence_ms=listening_config.get('post_speech_silence_ms', 800),
+            max_speech_duration_sec=listening_config.get('max_speech_duration_sec', 60.0),
+            min_speech_duration_sec=listening_config.get('min_speech_duration_sec', 0.5),
+        )
+        state_manager.continuous_listener = continuous_listener
+
+        realtime_preview = RealtimePreview(
+            whisper_engine=whisper_engine,
+            audio_stream_manager=audio_stream_manager,
+            on_preview_text=state_manager.handle_streaming_result,
+            preview_interval_sec=listening_config.get('preview_interval_sec', 1.5),
+            preview_max_audio_seconds=listening_config.get('preview_max_audio_seconds', 30.0),
+        )
+        state_manager.realtime_preview = realtime_preview
+
         audio_recorder = setup_audio_recorder(audio_config, audio_stream_manager, state_manager, vad_manager, streaming_manager)
         system_tray = setup_system_tray(tray_config, config_manager, state_manager, model_registry)
         state_manager.attach_components(audio_recorder, system_tray)
@@ -292,6 +317,12 @@ def main():
                 clipboard_manager.update_auto_paste(False)
 
         audio_stream_manager.start()
+
+        if state_manager.listening_mode == ListeningMode.CONTINUOUS:
+            continuous_listener.activate()
+
+        if state_manager.preview_enabled:
+            realtime_preview.activate()
 
         print("🚀 Whisper Key ready!")
         config_manager.print_startup_hotkey_instructions()

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -395,9 +395,6 @@ def main():
                 logger.warning("Wake word mode configured but engine unavailable; falling back to hotkey")
                 state_manager.listening_mode = ListeningMode.HOTKEY
 
-        if state_manager.preview_enabled:
-            realtime_preview.activate()
-
         print("🚀 Whisper Key ready!")
         config_manager.print_startup_hotkey_instructions()
         if http_trigger:

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -36,6 +36,7 @@ from .onboarding import check_gpu
 from .update_checker import check_for_updates
 from .http_trigger import HttpTrigger
 from .wake_word import HAS_OPENWAKEWORD, HAS_PORCUPINE, OpenWakeWordEngine, PorcupineEngine, WakeWordManager
+from .preview_overlay import PreviewOverlay
 from .utils import get_user_app_data_path, get_version
 
 def setup_logging(config_manager: ConfigManager):
@@ -323,6 +324,13 @@ def main():
             preview_max_audio_seconds=listening_config.get('preview_max_audio_seconds', 30.0),
         )
         state_manager.realtime_preview = realtime_preview
+
+        if listening_config.get('preview_show_overlay', False):
+            try:
+                preview_overlay = PreviewOverlay()
+                state_manager.preview_overlay = preview_overlay
+            except Exception as e:
+                logger.warning(f"Failed to create preview overlay: {e}")
 
         wake_word_config = config_manager.get_wake_word_config()
         wake_word_engine = setup_wake_word_engine(wake_word_config, logger)

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -31,6 +31,7 @@ from .voice_commands import VoiceCommandManager
 from .hardware_detection import detect_and_print as detect_hardware
 from .onboarding import check_gpu
 from .update_checker import check_for_updates
+from .http_trigger import HttpTrigger
 from .utils import get_user_app_data_path, get_version
 
 def setup_logging(config_manager: ConfigManager):
@@ -175,8 +176,7 @@ def setup_hotkey_listener(hotkey_config, state_manager, voice_commands_enabled=T
         stop_key=hotkey_config['stop_key'],
         auto_send_key=hotkey_config.get('auto_send_key'),
         cancel_combination=hotkey_config.get('cancel_combination'),
-        command_hotkey=hotkey_config.get('command_hotkey') if voice_commands_enabled else None,
-        recording_mode=hotkey_config.get('recording_mode', 'toggle')
+        command_hotkey=hotkey_config.get('command_hotkey') if voice_commands_enabled else None
     )
 
 def shutdown_app(hotkey_listener: HotkeyListener, state_manager: StateManager, logger: logging.Logger):
@@ -257,7 +257,20 @@ def main():
         audio_recorder = setup_audio_recorder(audio_config, state_manager, vad_manager, streaming_manager)
         system_tray = setup_system_tray(tray_config, config_manager, state_manager, model_registry)
         state_manager.attach_components(audio_recorder, system_tray)
-        
+
+        http_trigger_config = config_manager.config.get('http_trigger', {})
+        if http_trigger_config.get('enabled', True):
+            http_host = http_trigger_config.get('host', '0.0.0.0')
+            http_port = http_trigger_config.get('port', 5757)
+            try:
+                http_trigger = HttpTrigger(state_manager, host=http_host, port=http_port)
+                http_trigger.start()
+            except Exception as e:
+                logger.warning(f"Failed to start HTTP trigger: {e}")
+                http_trigger = None
+        else:
+            http_trigger = None
+
         hotkey_listener = setup_hotkey_listener(hotkey_config, state_manager, voice_commands_config['enabled'])
 
         system_tray.start()
@@ -271,6 +284,8 @@ def main():
 
         print("🚀 Whisper Key ready!")
         config_manager.print_startup_hotkey_instructions()
+        if http_trigger:
+            print(f"   [HTTP] trigger on http://{http_host}:{http_port}")
         print("   [CTRL+C] to quit", flush=True)
 
         app.run_event_loop(shutdown_event)

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -256,6 +256,9 @@ def main():
     logger = None
     
     try:
+        from .platform import monitors
+        monitors.set_dpi_awareness()
+
         config_manager = ConfigManager()
         setup_logging(config_manager)
         logger = logging.getLogger(__name__)
@@ -325,9 +328,10 @@ def main():
         )
         state_manager.realtime_preview = realtime_preview
 
+        overlay_config = config_manager.get_overlay_config()
         if listening_config.get('preview_show_overlay', False):
             try:
-                preview_overlay = PreviewOverlay()
+                preview_overlay = PreviewOverlay(overlay_config)
                 state_manager.preview_overlay = preview_overlay
             except Exception as e:
                 logger.warning(f"Failed to create preview overlay: {e}")

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -35,6 +35,7 @@ from .hardware_detection import detect_and_print as detect_hardware
 from .onboarding import check_gpu
 from .update_checker import check_for_updates
 from .http_trigger import HttpTrigger
+from .wake_word import HAS_OPENWAKEWORD, HAS_PORCUPINE, OpenWakeWordEngine, PorcupineEngine, WakeWordManager
 from .utils import get_user_app_data_path, get_version
 
 def setup_logging(config_manager: ConfigManager):
@@ -153,6 +154,46 @@ def setup_system_tray(tray_config, config_manager, state_manager, model_registry
         config_manager=config_manager,
         model_registry=model_registry
     )
+
+def setup_wake_word_engine(wake_word_config, logger):
+    engine_name = wake_word_config.get('engine', 'openwakeword')
+
+    if engine_name == 'openwakeword':
+        if not HAS_OPENWAKEWORD:
+            logger.warning("openwakeword not installed — wake word unavailable")
+            return None
+        try:
+            oww_config = wake_word_config.get('openwakeword', {})
+            model_paths = oww_config.get('model_paths', []) or None
+            threshold = oww_config.get('threshold', 0.5)
+            return OpenWakeWordEngine(model_paths=model_paths, threshold=threshold)
+        except Exception as e:
+            logger.error(f"Failed to initialize OpenWakeWord engine: {e}")
+            return None
+
+    elif engine_name == 'porcupine':
+        if not HAS_PORCUPINE:
+            logger.warning("pvporcupine not installed — wake word unavailable")
+            return None
+        try:
+            pv_config = wake_word_config.get('porcupine', {})
+            access_key = pv_config.get('access_key', '')
+            if not access_key:
+                logger.warning("Porcupine access_key not configured — wake word unavailable")
+                return None
+            return PorcupineEngine(
+                access_key=access_key,
+                keyword_paths=pv_config.get('keyword_paths', []) or None,
+                keywords=pv_config.get('keywords', []) or None,
+                sensitivities=pv_config.get('sensitivities', []) or None,
+            )
+        except Exception as e:
+            logger.error(f"Failed to initialize Porcupine engine: {e}")
+            return None
+
+    else:
+        logger.warning(f"Unknown wake word engine: {engine_name}")
+        return None
 
 def run_gpu_onboarding(config_manager, whisper_config):
     gpu_status = config_manager.config.get('onboarding', {}).get('gpu', 'pending')
@@ -283,6 +324,20 @@ def main():
         )
         state_manager.realtime_preview = realtime_preview
 
+        wake_word_config = config_manager.get_wake_word_config()
+        wake_word_engine = setup_wake_word_engine(wake_word_config, logger)
+        if wake_word_engine:
+            wake_word_manager = WakeWordManager(
+                audio_stream_manager=audio_stream_manager,
+                vad_manager=vad_manager,
+                engine=wake_word_engine,
+                on_wake_word=state_manager.handle_wake_word,
+                is_busy=state_manager.is_busy,
+                cooldown_sec=wake_word_config.get('cooldown_sec', 2.0),
+                vad_pre_filter=wake_word_config.get('vad_pre_filter', True),
+            )
+            state_manager.wake_word_manager = wake_word_manager
+
         audio_recorder = setup_audio_recorder(audio_config, audio_stream_manager, state_manager, vad_manager, streaming_manager)
         system_tray = setup_system_tray(tray_config, config_manager, state_manager, model_registry)
         state_manager.attach_components(audio_recorder, system_tray)
@@ -320,6 +375,13 @@ def main():
 
         if state_manager.listening_mode == ListeningMode.CONTINUOUS:
             continuous_listener.activate()
+
+        if state_manager.listening_mode == ListeningMode.WAKE_WORD:
+            if state_manager.wake_word_manager:
+                state_manager.wake_word_manager.activate()
+            else:
+                logger.warning("Wake word mode configured but engine unavailable; falling back to hotkey")
+                state_manager.listening_mode = ListeningMode.HOTKEY
 
         if state_manager.preview_enabled:
             realtime_preview.activate()

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -21,7 +21,7 @@ from .hotkey_listener import HotkeyListener
 from .whisper_engine import WhisperEngine
 from .voice_activity_detection import VadManager
 from .clipboard_manager import ClipboardManager
-from .state_manager import StateManager
+from .state_manager import StateManager, ListeningMode
 from .system_tray import SystemTray
 from .audio_feedback import AudioFeedback
 from .instance_manager import guard_against_multiple_instances
@@ -195,6 +195,8 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--test', action='store_true', help='Run as separate test instance')
+    parser.add_argument('--mode', choices=['hotkey', 'continuous', 'wake_word'], default=None)
+    parser.add_argument('--preview', action='store_true', default=None)
     args = parser.parse_args()
 
     instance_name = "WhisperKeyLocal_test" if args.test else "WhisperKeyLocal"
@@ -258,6 +260,11 @@ def main():
         system_tray = setup_system_tray(tray_config, config_manager, state_manager, model_registry)
         state_manager.attach_components(audio_recorder, system_tray)
 
+        if args.mode is not None:
+            state_manager.set_listening_mode(ListeningMode(args.mode))
+        if args.preview is True:
+            state_manager.set_preview_enabled(True)
+
         http_trigger_config = config_manager.config.get('http_trigger', {})
         if http_trigger_config.get('enabled', True):
             http_host = http_trigger_config.get('host', '0.0.0.0')
@@ -286,6 +293,9 @@ def main():
         config_manager.print_startup_hotkey_instructions()
         if http_trigger:
             print(f"   [HTTP] trigger on http://{http_host}:{http_port}")
+        mode_info = state_manager.get_mode_info()
+        preview_label = "on" if mode_info["preview"] else "off"
+        print(f"   [MODE] {mode_info['mode']} (preview: {preview_label})")
         print("   [CTRL+C] to quit", flush=True)
 
         app.run_event_loop(shutdown_event)

--- a/src/whisper_key/platform/__init__.py
+++ b/src/whisper_key/platform/__init__.py
@@ -5,6 +5,6 @@ IS_MACOS = PLATFORM == 'macos'
 IS_WINDOWS = PLATFORM == 'windows'
 
 if IS_MACOS:
-    from .macos import instance_lock, keyboard, hotkeys, paths, app, permissions, icons, gpu
+    from .macos import instance_lock, keyboard, hotkeys, paths, app, permissions, icons, gpu, monitors
 else:
-    from .windows import instance_lock, keyboard, hotkeys, paths, app, permissions, icons, gpu
+    from .windows import instance_lock, keyboard, hotkeys, paths, app, permissions, icons, gpu, monitors

--- a/src/whisper_key/platform/macos/monitors.py
+++ b/src/whisper_key/platform/macos/monitors.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class MonitorInfo:
+    index: int = 0
+    name: str = "Primary"
+    x: int = 0
+    y: int = 0
+    width: int = 1920
+    height: int = 1080
+    work_x: int = 0
+    work_y: int = 0
+    work_width: int = 1920
+    work_height: int = 1080
+    is_primary: bool = True
+
+
+def enumerate_monitors():
+    return [MonitorInfo()]
+
+
+def get_monitor_by_index(index):
+    return MonitorInfo()
+
+
+def get_primary_monitor():
+    return MonitorInfo()
+
+
+def get_monitor_at_cursor():
+    return MonitorInfo()
+
+
+def get_monitor_of_focused_window():
+    return MonitorInfo()
+
+
+def set_dpi_awareness():
+    pass

--- a/src/whisper_key/platform/windows/monitors.py
+++ b/src/whisper_key/platform/windows/monitors.py
@@ -1,0 +1,112 @@
+import ctypes
+import ctypes.wintypes as wintypes
+from dataclasses import dataclass
+
+user32 = ctypes.windll.user32
+
+MONITOR_DEFAULTTONEAREST = 2
+MONITORINFOF_PRIMARY = 1
+
+MonitorEnumProc = ctypes.WINFUNCTYPE(
+    wintypes.BOOL, wintypes.HMONITOR, wintypes.HDC,
+    ctypes.POINTER(wintypes.RECT), wintypes.LPARAM,
+)
+
+
+class MONITORINFOEXW(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("rcMonitor", wintypes.RECT),
+        ("rcWork", wintypes.RECT),
+        ("dwFlags", wintypes.DWORD),
+        ("szDevice", wintypes.WCHAR * 32),
+    ]
+
+
+@dataclass
+class MonitorInfo:
+    index: int
+    name: str
+    x: int
+    y: int
+    width: int
+    height: int
+    work_x: int
+    work_y: int
+    work_width: int
+    work_height: int
+    is_primary: bool
+
+
+def _info_from_hmonitor(hmonitor, index=0):
+    info = MONITORINFOEXW()
+    info.cbSize = ctypes.sizeof(MONITORINFOEXW)
+    user32.GetMonitorInfoW(hmonitor, ctypes.byref(info))
+    rm = info.rcMonitor
+    rw = info.rcWork
+    return MonitorInfo(
+        index=index,
+        name=info.szDevice,
+        x=rm.left, y=rm.top,
+        width=rm.right - rm.left, height=rm.bottom - rm.top,
+        work_x=rw.left, work_y=rw.top,
+        work_width=rw.right - rw.left, work_height=rw.bottom - rw.top,
+        is_primary=bool(info.dwFlags & MONITORINFOF_PRIMARY),
+    )
+
+
+def enumerate_monitors():
+    handles = []
+
+    def callback(hmonitor, hdc, rect, data):
+        handles.append(hmonitor)
+        return True
+
+    proc = MonitorEnumProc(callback)
+    user32.EnumDisplayMonitors(None, None, proc, 0)
+
+    monitors = [_info_from_hmonitor(h, i) for i, h in enumerate(handles)]
+    monitors.sort(key=lambda m: (m.x, m.y))
+    for i, m in enumerate(monitors):
+        m.index = i
+    return monitors
+
+
+def get_primary_monitor():
+    for m in enumerate_monitors():
+        if m.is_primary:
+            return m
+    monitors = enumerate_monitors()
+    return monitors[0] if monitors else MonitorInfo(0, "", 0, 0, 1920, 1080, 0, 0, 1920, 1080, True)
+
+
+def get_monitor_by_index(index):
+    monitors = enumerate_monitors()
+    if 0 <= index < len(monitors):
+        return monitors[index]
+    return get_primary_monitor()
+
+
+def get_monitor_at_cursor():
+    point = wintypes.POINT()
+    user32.GetCursorPos(ctypes.byref(point))
+    hmonitor = user32.MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST)
+    return _info_from_hmonitor(hmonitor)
+
+
+def get_monitor_of_focused_window():
+    hwnd = user32.GetForegroundWindow()
+    if not hwnd:
+        return get_monitor_at_cursor()
+    hmonitor = user32.MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)
+    return _info_from_hmonitor(hmonitor)
+
+
+def set_dpi_awareness():
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)
+    except Exception:
+        try:
+            user32.SetProcessDPIAware()
+        except Exception:
+            pass

--- a/src/whisper_key/preview_overlay.py
+++ b/src/whisper_key/preview_overlay.py
@@ -1,15 +1,58 @@
-import ctypes
-import ctypes.wintypes
 import logging
 import threading
 
+from .platform import monitors
+
+DEFAULTS = {
+    'monitor': 'follow_focus',
+    'position': 'bottom_center',
+    'margin': 80,
+    'font_size': 16,
+    'opacity': 0.85,
+    'bg_color': '#1e1e1e',
+    'text_color': '#ffffff',
+}
+
+POSITION_CALCULATORS = {
+    'bottom_center': lambda m, ww, wh, mg: (
+        m.work_x + (m.work_width - ww) // 2,
+        m.work_y + m.work_height - wh - mg,
+    ),
+    'top_center': lambda m, ww, wh, mg: (
+        m.work_x + (m.work_width - ww) // 2,
+        m.work_y + mg,
+    ),
+    'bottom_left': lambda m, ww, wh, mg: (
+        m.work_x + mg,
+        m.work_y + m.work_height - wh - mg,
+    ),
+    'bottom_right': lambda m, ww, wh, mg: (
+        m.work_x + m.work_width - ww - mg,
+        m.work_y + m.work_height - wh - mg,
+    ),
+    'top_left': lambda m, ww, wh, mg: (
+        m.work_x + mg,
+        m.work_y + mg,
+    ),
+    'top_right': lambda m, ww, wh, mg: (
+        m.work_x + m.work_width - ww - mg,
+        m.work_y + mg,
+    ),
+    'center': lambda m, ww, wh, mg: (
+        m.work_x + (m.work_width - ww) // 2,
+        m.work_y + (m.work_height - wh) // 2,
+    ),
+}
+
 
 class PreviewOverlay:
-    def __init__(self):
+    def __init__(self, overlay_config: dict = None):
         self.logger = logging.getLogger(__name__)
+        self._config = {**DEFAULTS, **(overlay_config or {})}
         self._root = None
-        self._label = None
+        self._windows = {}
         self._visible = False
+        self._all_mode = self._config['monitor'] == 'all'
         self._ready = threading.Event()
         self._thread = threading.Thread(target=self._run_tk, daemon=True)
         self._thread.start()
@@ -17,30 +60,20 @@ class PreviewOverlay:
 
     def _run_tk(self):
         try:
+            monitors.set_dpi_awareness()
             import tkinter as tk
-            import tkinter.font as tkfont
+            self._tk = tk
 
             self._root = tk.Tk()
             self._root.withdraw()
             self._root.overrideredirect(True)
             self._root.attributes("-topmost", True)
-            self._root.attributes("-alpha", 0.85)
-            self._root.configure(bg="#1e1e1e")
 
-            font = tkfont.Font(family="Segoe UI", size=16, weight="bold")
-
-            self._label = tk.Label(
-                self._root,
-                text="",
-                font=font,
-                fg="#ffffff",
-                bg="#1e1e1e",
-                wraplength=700,
-                justify="center",
-                padx=20,
-                pady=12,
-            )
-            self._label.pack()
+            if self._all_mode:
+                self._build_all_windows()
+            else:
+                self._apply_style(self._root)
+                self._windows[0] = _OverlayWindow(self._root, self._root, self._make_label(self._root))
 
             self._ready.set()
             self._root.mainloop()
@@ -48,48 +81,81 @@ class PreviewOverlay:
             self.logger.error(f"Preview overlay failed: {e}")
             self._ready.set()
 
-    def _get_active_monitor(self):
-        try:
-            import ctypes
-            point = ctypes.wintypes.POINT()
-            ctypes.windll.user32.GetCursorPos(ctypes.byref(point))
+    def _make_label(self, parent):
+        import tkinter.font as tkfont
+        font = tkfont.Font(family="Segoe UI", size=self._config['font_size'], weight="bold")
+        label = self._tk.Label(
+            parent,
+            text="",
+            font=font,
+            fg=self._config['text_color'],
+            bg=self._config['bg_color'],
+            wraplength=700,
+            justify="center",
+            padx=20,
+            pady=12,
+        )
+        label.pack()
+        return label
 
-            class MONITORINFO(ctypes.Structure):
-                _fields_ = [
-                    ("cbSize", ctypes.wintypes.DWORD),
-                    ("rcMonitor", ctypes.wintypes.RECT),
-                    ("rcWork", ctypes.wintypes.RECT),
-                    ("dwFlags", ctypes.wintypes.DWORD),
-                ]
+    def _apply_style(self, window):
+        window.attributes("-alpha", self._config['opacity'])
+        window.configure(bg=self._config['bg_color'])
 
-            monitor = ctypes.windll.user32.MonitorFromPoint(point, 2)
-            info = MONITORINFO()
-            info.cbSize = ctypes.sizeof(MONITORINFO)
-            ctypes.windll.user32.GetMonitorInfoW(monitor, ctypes.byref(info))
-            r = info.rcWork
-            return r.left, r.top, r.right - r.left, r.bottom - r.top
-        except Exception:
-            return 0, 0, self._root.winfo_screenwidth(), self._root.winfo_screenheight()
+    def _build_all_windows(self):
+        self._destroy_extra_windows()
+        for mon in monitors.enumerate_monitors():
+            top = self._tk.Toplevel(self._root)
+            top.withdraw()
+            top.overrideredirect(True)
+            top.attributes("-topmost", True)
+            self._apply_style(top)
+            label = self._make_label(top)
+            self._windows[mon.index] = _OverlayWindow(top, top, label, mon)
 
-    def _position_bottom_center(self):
-        self._root.update_idletasks()
-        mon_x, mon_y, mon_w, mon_h = self._get_active_monitor()
-        win_w = self._root.winfo_reqwidth()
-        win_h = self._root.winfo_reqheight()
-        x = mon_x + (mon_w - win_w) // 2
-        y = mon_y + mon_h - win_h - 80
-        self._root.geometry(f"+{x}+{y}")
+    def _destroy_extra_windows(self):
+        for ow in self._windows.values():
+            if ow.toplevel is not self._root:
+                ow.toplevel.destroy()
+        self._windows.clear()
+
+    def _resolve_target_monitor(self):
+        mode = self._config.get('monitor', 'follow_focus')
+        if mode == 'follow_focus':
+            return monitors.get_monitor_of_focused_window()
+        if mode == 'cursor':
+            return monitors.get_monitor_at_cursor()
+        if mode == 'primary':
+            return monitors.get_primary_monitor()
+        if isinstance(mode, int):
+            return monitors.get_monitor_by_index(mode)
+        return monitors.get_primary_monitor()
+
+    def _calculate_position(self, monitor, win_w, win_h):
+        position = self._config.get('position', 'bottom_center')
+        margin = self._config.get('margin', 80)
+        calc = POSITION_CALCULATORS.get(position, POSITION_CALCULATORS['bottom_center'])
+        return calc(monitor, win_w, win_h, margin)
+
+    def _position_window(self, ow):
+        ow.toplevel.update_idletasks()
+        mon = ow.fixed_monitor if ow.fixed_monitor else self._resolve_target_monitor()
+        win_w = ow.toplevel.winfo_reqwidth()
+        win_h = ow.toplevel.winfo_reqheight()
+        x, y = self._calculate_position(mon, win_w, win_h)
+        ow.toplevel.geometry(f"+{x}+{y}")
 
     def update_text(self, text):
-        if not self._root or not self._label:
+        if not self._root:
             return
 
         def _update():
-            self._label.configure(text=text)
-            self._position_bottom_center()
-            if not self._visible:
-                self._root.deiconify()
-                self._visible = True
+            for ow in self._windows.values():
+                ow.label.configure(text=text)
+                self._position_window(ow)
+                if not self._visible:
+                    ow.toplevel.deiconify()
+            self._visible = True
 
         self._root.after(0, _update)
 
@@ -98,7 +164,8 @@ class PreviewOverlay:
             return
 
         def _show():
-            self._root.deiconify()
+            for ow in self._windows.values():
+                ow.toplevel.deiconify()
             self._visible = True
 
         self._root.after(0, _show)
@@ -108,7 +175,52 @@ class PreviewOverlay:
             return
 
         def _hide():
-            self._root.withdraw()
+            for ow in self._windows.values():
+                ow.toplevel.withdraw()
             self._visible = False
 
         self._root.after(0, _hide)
+
+    def update_config(self, overlay_config: dict):
+        if not self._root:
+            return
+
+        old_monitor = self._config.get('monitor')
+        self._config = {**DEFAULTS, **(overlay_config or {})}
+        new_monitor = self._config.get('monitor')
+        new_all_mode = new_monitor == 'all'
+
+        def _apply():
+            if new_all_mode != self._all_mode:
+                self._all_mode = new_all_mode
+                if new_all_mode:
+                    self._build_all_windows()
+                else:
+                    self._destroy_extra_windows()
+                    self._apply_style(self._root)
+                    self._windows[0] = _OverlayWindow(
+                        self._root, self._root, self._make_label(self._root),
+                    )
+
+            for ow in self._windows.values():
+                self._apply_style(ow.toplevel)
+                ow.label.configure(
+                    fg=self._config['text_color'],
+                    bg=self._config['bg_color'],
+                )
+
+            if self._visible:
+                for ow in self._windows.values():
+                    self._position_window(ow)
+
+        self._root.after(0, _apply)
+
+
+class _OverlayWindow:
+    __slots__ = ('toplevel', 'root', 'label', 'fixed_monitor')
+
+    def __init__(self, toplevel, root, label, fixed_monitor=None):
+        self.toplevel = toplevel
+        self.root = root
+        self.label = label
+        self.fixed_monitor = fixed_monitor

--- a/src/whisper_key/preview_overlay.py
+++ b/src/whisper_key/preview_overlay.py
@@ -1,3 +1,5 @@
+import ctypes
+import ctypes.wintypes
 import logging
 import threading
 
@@ -46,14 +48,36 @@ class PreviewOverlay:
             self.logger.error(f"Preview overlay failed: {e}")
             self._ready.set()
 
+    def _get_active_monitor(self):
+        try:
+            import ctypes
+            point = ctypes.wintypes.POINT()
+            ctypes.windll.user32.GetCursorPos(ctypes.byref(point))
+
+            class MONITORINFO(ctypes.Structure):
+                _fields_ = [
+                    ("cbSize", ctypes.wintypes.DWORD),
+                    ("rcMonitor", ctypes.wintypes.RECT),
+                    ("rcWork", ctypes.wintypes.RECT),
+                    ("dwFlags", ctypes.wintypes.DWORD),
+                ]
+
+            monitor = ctypes.windll.user32.MonitorFromPoint(point, 2)
+            info = MONITORINFO()
+            info.cbSize = ctypes.sizeof(MONITORINFO)
+            ctypes.windll.user32.GetMonitorInfoW(monitor, ctypes.byref(info))
+            r = info.rcWork
+            return r.left, r.top, r.right - r.left, r.bottom - r.top
+        except Exception:
+            return 0, 0, self._root.winfo_screenwidth(), self._root.winfo_screenheight()
+
     def _position_bottom_center(self):
         self._root.update_idletasks()
-        screen_w = self._root.winfo_screenwidth()
-        screen_h = self._root.winfo_screenheight()
+        mon_x, mon_y, mon_w, mon_h = self._get_active_monitor()
         win_w = self._root.winfo_reqwidth()
         win_h = self._root.winfo_reqheight()
-        x = (screen_w - win_w) // 2
-        y = screen_h - win_h - 80
+        x = mon_x + (mon_w - win_w) // 2
+        y = mon_y + mon_h - win_h - 80
         self._root.geometry(f"+{x}+{y}")
 
     def update_text(self, text):

--- a/src/whisper_key/preview_overlay.py
+++ b/src/whisper_key/preview_overlay.py
@@ -1,0 +1,90 @@
+import logging
+import threading
+
+
+class PreviewOverlay:
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+        self._root = None
+        self._label = None
+        self._visible = False
+        self._ready = threading.Event()
+        self._thread = threading.Thread(target=self._run_tk, daemon=True)
+        self._thread.start()
+        self._ready.wait(timeout=5)
+
+    def _run_tk(self):
+        try:
+            import tkinter as tk
+            import tkinter.font as tkfont
+
+            self._root = tk.Tk()
+            self._root.withdraw()
+            self._root.overrideredirect(True)
+            self._root.attributes("-topmost", True)
+            self._root.attributes("-alpha", 0.85)
+            self._root.configure(bg="#1e1e1e")
+
+            font = tkfont.Font(family="Segoe UI", size=16, weight="bold")
+
+            self._label = tk.Label(
+                self._root,
+                text="",
+                font=font,
+                fg="#ffffff",
+                bg="#1e1e1e",
+                wraplength=700,
+                justify="center",
+                padx=20,
+                pady=12,
+            )
+            self._label.pack()
+
+            self._ready.set()
+            self._root.mainloop()
+        except Exception as e:
+            self.logger.error(f"Preview overlay failed: {e}")
+            self._ready.set()
+
+    def _position_bottom_center(self):
+        self._root.update_idletasks()
+        screen_w = self._root.winfo_screenwidth()
+        screen_h = self._root.winfo_screenheight()
+        win_w = self._root.winfo_reqwidth()
+        win_h = self._root.winfo_reqheight()
+        x = (screen_w - win_w) // 2
+        y = screen_h - win_h - 80
+        self._root.geometry(f"+{x}+{y}")
+
+    def update_text(self, text):
+        if not self._root or not self._label:
+            return
+
+        def _update():
+            self._label.configure(text=text)
+            self._position_bottom_center()
+            if not self._visible:
+                self._root.deiconify()
+                self._visible = True
+
+        self._root.after(0, _update)
+
+    def show(self):
+        if not self._root:
+            return
+
+        def _show():
+            self._root.deiconify()
+            self._visible = True
+
+        self._root.after(0, _show)
+
+    def hide(self):
+        if not self._root:
+            return
+
+        def _hide():
+            self._root.withdraw()
+            self._visible = False
+
+        self._root.after(0, _hide)

--- a/src/whisper_key/realtime_preview.py
+++ b/src/whisper_key/realtime_preview.py
@@ -91,7 +91,7 @@ class RealtimePreview:
             text = self.whisper_engine.transcribe_preview(snapshot)
 
             if text and self.on_preview_text and self._active:
-                self.on_preview_text(text)
+                self.on_preview_text(text, False)
 
         except Exception as e:
             self.logger.error(f"Preview cycle failed: {e}")

--- a/src/whisper_key/realtime_preview.py
+++ b/src/whisper_key/realtime_preview.py
@@ -1,0 +1,99 @@
+import logging
+import threading
+from typing import Optional, Callable
+
+import numpy as np
+
+from .audio_stream import AudioStreamManager, WHISPER_SAMPLE_RATE
+from .whisper_engine import WhisperEngine
+
+
+class RealtimePreview:
+    def __init__(self,
+                 whisper_engine: WhisperEngine,
+                 audio_stream_manager: AudioStreamManager,
+                 on_preview_text: Optional[Callable[[str], None]] = None,
+                 preview_interval_sec: float = 1.5,
+                 preview_max_audio_seconds: float = 30.0):
+
+        self.whisper_engine = whisper_engine
+        self.audio_stream_manager = audio_stream_manager
+        self.on_preview_text = on_preview_text
+        self.preview_interval_sec = preview_interval_sec
+        self.preview_max_audio_seconds = preview_max_audio_seconds
+
+        self._buffer_lock = threading.Lock()
+        self._buffer = np.array([], dtype=np.float32)
+        self._active = False
+        self._timer: Optional[threading.Timer] = None
+        self._max_samples = int(preview_max_audio_seconds * WHISPER_SAMPLE_RATE)
+        self.logger = logging.getLogger(__name__)
+
+    def activate(self):
+        if self._active:
+            return
+
+        self._active = True
+        with self._buffer_lock:
+            self._buffer = np.array([], dtype=np.float32)
+
+        self.audio_stream_manager.add_consumer(self._on_audio_chunk)
+        self._schedule_next_preview()
+        self.logger.info("Realtime preview activated")
+
+    def deactivate(self):
+        if not self._active:
+            return
+
+        self._active = False
+
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None
+
+        self.audio_stream_manager.remove_consumer(self._on_audio_chunk)
+
+        with self._buffer_lock:
+            self._buffer = np.array([], dtype=np.float32)
+
+        self.logger.info("Realtime preview deactivated")
+
+    def _on_audio_chunk(self, audio_data):
+        if not self._active:
+            return
+
+        chunk = audio_data.flatten().astype(np.float32)
+        if self.audio_stream_manager.needs_resampling():
+            chunk = self.audio_stream_manager.resample_to_whisper(chunk)
+
+        with self._buffer_lock:
+            self._buffer = np.concatenate([self._buffer, chunk])
+            if len(self._buffer) > self._max_samples:
+                self._buffer = self._buffer[-self._max_samples:]
+
+    def _schedule_next_preview(self):
+        if not self._active:
+            return
+        self._timer = threading.Timer(self.preview_interval_sec, self._run_preview)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _run_preview(self):
+        if not self._active:
+            return
+
+        try:
+            with self._buffer_lock:
+                if len(self._buffer) == 0:
+                    return
+                snapshot = self._buffer.copy()
+
+            text = self.whisper_engine.transcribe_preview(snapshot)
+
+            if text and self.on_preview_text and self._active:
+                self.on_preview_text(text)
+
+        except Exception as e:
+            self.logger.error(f"Preview cycle failed: {e}")
+        finally:
+            self._schedule_next_preview()

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -8,6 +8,7 @@ from typing import Optional
 import sounddevice as sd
 
 from .audio_recorder import AudioRecorder
+from .audio_stream import AudioStreamManager
 from .whisper_engine import WhisperEngine
 from .clipboard_manager import ClipboardManager
 from .system_tray import SystemTray
@@ -32,7 +33,8 @@ class StateManager:
                  vad_manager: VadManager,
                  system_tray: Optional[SystemTray] = None,
                  audio_feedback: Optional[AudioFeedback] = None,
-                 voice_command_manager: Optional[VoiceCommandManager] = None):
+                 voice_command_manager: Optional[VoiceCommandManager] = None,
+                 audio_stream_manager: Optional[AudioStreamManager] = None):
 
         self.audio_recorder = audio_recorder
         self.whisper_engine = whisper_engine
@@ -42,6 +44,7 @@ class StateManager:
         self.audio_feedback = OptionalComponent(audio_feedback)
         self.vad_manager = vad_manager
         self.voice_command_manager = voice_command_manager
+        self.audio_stream_manager = audio_stream_manager
 
         self.is_processing = False
         self.is_model_loading = False
@@ -277,12 +280,15 @@ class StateManager:
             self.logger.error(f"Manual test failed: {e}")
             print(f"❌ Test failed: {e}")
     
-    def shutdown(self):        
+    def shutdown(self):
         print("Whisper Key is shutting down... goodbye!")
 
         if self.audio_recorder.get_recording_status():
             self.audio_recorder.stop_recording()
-        
+
+        if self.audio_stream_manager:
+            self.audio_stream_manager.stop()
+
         self.system_tray.stop()
     
     def set_model_loading(self, loading: bool):
@@ -371,10 +377,10 @@ class StateManager:
 
     def get_available_audio_devices(self, host_filter: Optional[str] = None):
         host_name = host_filter if host_filter is not None else self._current_audio_host
-        return AudioRecorder.get_available_audio_devices(host_name)
+        return AudioStreamManager.get_available_audio_devices(host_name)
 
     def get_current_audio_device_id(self):
-        return self.audio_recorder.get_device_id()
+        return self.audio_stream_manager.get_device_id()
 
     def get_available_audio_hosts(self):
         try:
@@ -434,7 +440,7 @@ class StateManager:
     def request_audio_device_change(self, device_id: int, device_name: str):
         current_state = self.get_current_state()
 
-        if device_id == self.audio_recorder.device:
+        if device_id == self.audio_stream_manager.device:
             return True
 
         if current_state == "recording":
@@ -458,31 +464,10 @@ class StateManager:
     def _execute_audio_device_change(self, device_id: int, device_name: str):
         try:
             print(f"🎤 Switching to: {device_name}")
-
-            channels = self.audio_recorder.channels
-            dtype = self.audio_recorder.dtype
-            max_duration = self.audio_recorder.max_duration
-            on_max_duration = self.audio_recorder.on_max_duration_reached
-            vad_manager = self.audio_recorder.vad_manager
-            streaming_manager = self.audio_recorder.streaming_manager
-            on_streaming_result = self.audio_recorder.on_streaming_result
-
-            new_recorder = AudioRecorder(
-                on_vad_event=self.handle_vad_event,
-                channels=channels,
-                dtype=dtype,
-                max_duration=max_duration,
-                on_max_duration_reached=on_max_duration,
-                vad_manager=vad_manager,
-                streaming_manager=streaming_manager,
-                on_streaming_result=on_streaming_result,
+            self.audio_stream_manager.restart_stream(
                 device=device_id if device_id != -1 else None
             )
-
-            self.audio_recorder = new_recorder
-
             print(f"✅ Successfully switched audio device to: {device_name}")
-
         except Exception as e:
             self.logger.error(f"Failed to change audio device: {e}")
             print(f"❌ Failed to switch audio device: {e}")
@@ -530,11 +515,11 @@ class StateManager:
         return None
 
     def _ensure_audio_device_for_host(self, host_name: Optional[str]):
-        if not host_name or not self.audio_recorder:
+        if not host_name or not self.audio_stream_manager:
             return
 
         try:
-            current_device_id = self.audio_recorder.get_device_id()
+            current_device_id = self.audio_stream_manager.get_device_id()
         except Exception as e:
             self.logger.error(f"Unable to read current audio device: {e}")
             return

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -99,14 +99,18 @@ class StateManager:
 
     def handle_max_recording_duration_reached(self, audio_data):
         self.logger.info("Max recording duration reached - starting transcription")
+        if self.realtime_preview:
+            self.realtime_preview.deactivate()
         self._transcription_pipeline(audio_data, use_auto_enter=False)
 
     def handle_vad_event(self, event: VadEvent):
         if event == VadEvent.SILENCE_TIMEOUT:
             self.logger.info("VAD silence timeout detected - stopping recording")
             timeout_seconds = int(self.vad_manager.vad_silence_timeout_seconds)
-            self._clear_streaming_display()
             print(f"⏰ Stopping recording after {timeout_seconds} seconds of silence...")
+            if self.realtime_preview:
+                self.realtime_preview.deactivate()
+            self._clear_streaming_display()
             audio_data = self.audio_recorder.stop_recording()
             self._transcription_pipeline(audio_data, use_auto_enter=False)
 
@@ -250,6 +254,11 @@ class StateManager:
             if success:
                 self.last_transcription = transcribed_text
                 self.audio_feedback.play_transcription_complete_sound()
+                if self.preview_show_overlay and self.preview_overlay:
+                    self.preview_overlay.update_text(transcribed_text)
+                    hide_delay = self.config_manager.get_overlay_config().get('hide_after_sec', 3.0)
+                    if hide_delay > 0:
+                        threading.Timer(hide_delay, self.preview_overlay.hide).start()
             
         except Exception as e:
             self.logger.error(f"Error in processing workflow: {e}")

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -2,6 +2,7 @@ import logging
 import time
 import threading
 import platform
+from enum import Enum
 from typing import Optional
 
 import sounddevice as sd
@@ -15,6 +16,12 @@ from .audio_feedback import AudioFeedback
 from .utils import OptionalComponent
 from .voice_activity_detection import VadEvent, VadManager
 from .voice_commands import VoiceCommandManager
+
+
+class ListeningMode(Enum):
+    HOTKEY = "hotkey"
+    CONTINUOUS = "continuous"
+    WAKE_WORD = "wake_word"
 
 class StateManager:
     def __init__(self,
@@ -44,6 +51,10 @@ class StateManager:
         self._command_mode = False
         self._state_lock = threading.Lock()
         self._streaming_display_active = False
+
+        listening_config = self.config_manager.get_listening_config()
+        self.listening_mode = ListeningMode(listening_config.get('mode', 'hotkey'))
+        self.preview_enabled = listening_config.get('preview_enabled', False)
 
         self.logger = logging.getLogger(__name__)
         self._current_audio_host = None
@@ -225,13 +236,29 @@ class StateManager:
         else:
             print("   ✗ No matching command found")
 
+    def set_listening_mode(self, mode: ListeningMode):
+        self.listening_mode = mode
+        self.config_manager.update_listening_mode(mode.value)
+        self.logger.info(f"Listening mode changed to {mode.value}")
+
+    def set_preview_enabled(self, enabled: bool):
+        self.preview_enabled = enabled
+        self.config_manager.update_listening_preview(enabled)
+        self.logger.info(f"Preview {'enabled' if enabled else 'disabled'}")
+
+    def get_mode_info(self) -> dict:
+        return {
+            "mode": self.listening_mode.value,
+            "preview": self.preview_enabled,
+        }
+
     def get_application_state(self) -> dict:
         status = {
             "recording": self.audio_recorder.get_recording_status(),
             "processing": self.is_processing,
             "model_loading": self.is_model_loading,
         }
-        
+
         return status
     
     def manual_transcribe_test(self, duration_seconds: int = 5):

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -324,7 +324,7 @@ class StateManager:
         self.logger.info(f"Overlay {'enabled' if enabled else 'disabled'}")
         if self.preview_overlay:
             if enabled:
-                self.preview_overlay.update_config()
+                self.preview_overlay.update_config(self.config_manager.get_overlay_config())
             else:
                 self.preview_overlay.hide()
 
@@ -332,13 +332,13 @@ class StateManager:
         self.config_manager.update_overlay_setting('monitor', value)
         self.logger.info(f"Overlay monitor set to {value}")
         if self.preview_overlay and self.preview_show_overlay:
-            self.preview_overlay.update_config()
+            self.preview_overlay.update_config(self.config_manager.get_overlay_config())
 
     def set_overlay_position(self, value: str):
         self.config_manager.update_overlay_setting('position', value)
         self.logger.info(f"Overlay position set to {value}")
         if self.preview_overlay and self.preview_show_overlay:
-            self.preview_overlay.update_config()
+            self.preview_overlay.update_config(self.config_manager.get_overlay_config())
 
     def get_overlay_config(self) -> dict:
         overlay = self.config_manager.get_overlay_config()

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -19,6 +19,7 @@ from .voice_activity_detection import VadEvent, VadManager
 from .voice_commands import VoiceCommandManager
 from .continuous_listener import ContinuousListener
 from .realtime_preview import RealtimePreview
+from .wake_word import WakeWordManager
 
 
 class ListeningMode(Enum):
@@ -50,6 +51,7 @@ class StateManager:
         self.audio_stream_manager = audio_stream_manager
         self.continuous_listener = continuous_listener
         self.realtime_preview = None
+        self.wake_word_manager: Optional[WakeWordManager] = None
 
         self.is_processing = False
         self.is_model_loading = False
@@ -79,6 +81,10 @@ class StateManager:
         self._transcription_pipeline(audio_data, use_auto_enter=False)
         if self.listening_mode == ListeningMode.CONTINUOUS:
             print("   [CONTINUOUS] listening for speech...")
+
+    def handle_wake_word(self):
+        self.logger.info("Wake word triggered — starting recording")
+        self.start_recording()
 
     def is_busy(self) -> bool:
         with self._state_lock:
@@ -265,6 +271,18 @@ class StateManager:
             elif old_mode == ListeningMode.CONTINUOUS:
                 self.continuous_listener.deactivate()
 
+        if self.wake_word_manager:
+            if mode == ListeningMode.WAKE_WORD:
+                self.wake_word_manager.activate()
+            elif old_mode == ListeningMode.WAKE_WORD:
+                self.wake_word_manager.deactivate()
+
+        if mode == ListeningMode.WAKE_WORD and not self.wake_word_manager:
+            self.logger.warning("Wake word mode requested but no engine available; falling back to hotkey")
+            self.listening_mode = ListeningMode.HOTKEY
+            self.config_manager.update_listening_mode(ListeningMode.HOTKEY.value)
+            print("   [WAKE WORD] engine not available — falling back to hotkey mode")
+
     def set_preview_enabled(self, enabled: bool):
         old = self.preview_enabled
         self.preview_enabled = enabled
@@ -312,6 +330,9 @@ class StateManager:
 
         if self.continuous_listener:
             self.continuous_listener.deactivate()
+
+        if self.wake_word_manager:
+            self.wake_word_manager.cleanup()
 
         if self.audio_recorder.get_recording_status():
             self.audio_recorder.stop_recording()

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -318,10 +318,39 @@ class StateManager:
             elif not enabled and old:
                 self.realtime_preview.deactivate()
 
+    def set_overlay_enabled(self, enabled: bool):
+        self.preview_show_overlay = enabled
+        self.config_manager.update_user_setting('listening', 'preview_show_overlay', enabled)
+        self.logger.info(f"Overlay {'enabled' if enabled else 'disabled'}")
+        if self.preview_overlay:
+            if enabled:
+                self.preview_overlay.update_config()
+            else:
+                self.preview_overlay.hide()
+
+    def set_overlay_monitor(self, value):
+        self.config_manager.update_overlay_setting('monitor', value)
+        self.logger.info(f"Overlay monitor set to {value}")
+        if self.preview_overlay and self.preview_show_overlay:
+            self.preview_overlay.update_config()
+
+    def set_overlay_position(self, value: str):
+        self.config_manager.update_overlay_setting('position', value)
+        self.logger.info(f"Overlay position set to {value}")
+        if self.preview_overlay and self.preview_show_overlay:
+            self.preview_overlay.update_config()
+
+    def get_overlay_config(self) -> dict:
+        overlay = self.config_manager.get_overlay_config()
+        overlay['overlay_enabled'] = self.preview_show_overlay
+        return overlay
+
     def get_mode_info(self) -> dict:
         return {
             "mode": self.listening_mode.value,
             "preview": self.preview_enabled,
+            "overlay": self.preview_show_overlay,
+            "overlay_monitor": self.config_manager.get_overlay_config().get('monitor', 'follow_focus'),
         }
 
     def get_application_state(self) -> dict:

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -8,7 +8,7 @@ from typing import Optional
 import sounddevice as sd
 
 from .audio_recorder import AudioRecorder
-from .audio_stream import AudioStreamManager
+from .audio_stream import AudioStreamManager, WHISPER_SAMPLE_RATE
 from .whisper_engine import WhisperEngine
 from .clipboard_manager import ClipboardManager
 from .system_tray import SystemTray
@@ -17,6 +17,8 @@ from .audio_feedback import AudioFeedback
 from .utils import OptionalComponent
 from .voice_activity_detection import VadEvent, VadManager
 from .voice_commands import VoiceCommandManager
+from .continuous_listener import ContinuousListener
+from .realtime_preview import RealtimePreview
 
 
 class ListeningMode(Enum):
@@ -34,7 +36,8 @@ class StateManager:
                  system_tray: Optional[SystemTray] = None,
                  audio_feedback: Optional[AudioFeedback] = None,
                  voice_command_manager: Optional[VoiceCommandManager] = None,
-                 audio_stream_manager: Optional[AudioStreamManager] = None):
+                 audio_stream_manager: Optional[AudioStreamManager] = None,
+                 continuous_listener: Optional[ContinuousListener] = None):
 
         self.audio_recorder = audio_recorder
         self.whisper_engine = whisper_engine
@@ -45,6 +48,8 @@ class StateManager:
         self.vad_manager = vad_manager
         self.voice_command_manager = voice_command_manager
         self.audio_stream_manager = audio_stream_manager
+        self.continuous_listener = continuous_listener
+        self.realtime_preview = None
 
         self.is_processing = False
         self.is_model_loading = False
@@ -70,6 +75,15 @@ class StateManager:
         self.system_tray = OptionalComponent(system_tray)
         self._ensure_audio_device_for_host(self._current_audio_host)
     
+    def handle_continuous_audio(self, audio_data):
+        self._transcription_pipeline(audio_data, use_auto_enter=False)
+        if self.listening_mode == ListeningMode.CONTINUOUS:
+            print("   [CONTINUOUS] listening for speech...")
+
+    def is_busy(self) -> bool:
+        with self._state_lock:
+            return self.is_processing or self.is_model_loading or self.audio_recorder.get_recording_status()
+
     def handle_max_recording_duration_reached(self, audio_data):
         self.logger.info("Max recording duration reached - starting transcription")
         self._transcription_pipeline(audio_data, use_auto_enter=False)
@@ -175,7 +189,7 @@ class StateManager:
             if audio_data is None:
                 return
 
-            duration = self.audio_recorder.get_audio_duration(audio_data)
+            duration = len(audio_data) / WHISPER_SAMPLE_RATE
             print(f"   ✓ Recorded {duration:.1f} seconds, transcribing...")
 
             self.system_tray.update_state("processing")
@@ -240,14 +254,27 @@ class StateManager:
             print("   ✗ No matching command found")
 
     def set_listening_mode(self, mode: ListeningMode):
+        old_mode = self.listening_mode
         self.listening_mode = mode
         self.config_manager.update_listening_mode(mode.value)
         self.logger.info(f"Listening mode changed to {mode.value}")
 
+        if self.continuous_listener:
+            if mode == ListeningMode.CONTINUOUS:
+                self.continuous_listener.activate()
+            elif old_mode == ListeningMode.CONTINUOUS:
+                self.continuous_listener.deactivate()
+
     def set_preview_enabled(self, enabled: bool):
+        old = self.preview_enabled
         self.preview_enabled = enabled
         self.config_manager.update_listening_preview(enabled)
         self.logger.info(f"Preview {'enabled' if enabled else 'disabled'}")
+        if self.realtime_preview:
+            if enabled and not old:
+                self.realtime_preview.activate()
+            elif not enabled and old:
+                self.realtime_preview.deactivate()
 
     def get_mode_info(self) -> dict:
         return {
@@ -282,6 +309,9 @@ class StateManager:
     
     def shutdown(self):
         print("Whisper Key is shutting down... goodbye!")
+
+        if self.continuous_listener:
+            self.continuous_listener.deactivate()
 
         if self.audio_recorder.get_recording_status():
             self.audio_recorder.stop_recording()

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -61,10 +61,15 @@ class StateManager:
         self._command_mode = False
         self._state_lock = threading.Lock()
         self._streaming_display_active = False
+        self._last_preview_text = ""
+        self._preview_active = False
+        self.preview_overlay = None
 
         listening_config = self.config_manager.get_listening_config()
         self.listening_mode = ListeningMode(listening_config.get('mode', 'hotkey'))
         self.preview_enabled = listening_config.get('preview_enabled', False)
+        self.preview_show_tooltip = listening_config.get('preview_show_tooltip', True)
+        self.preview_show_overlay = listening_config.get('preview_show_overlay', False)
 
         self.logger = logging.getLogger(__name__)
         self._current_audio_host = None
@@ -105,13 +110,32 @@ class StateManager:
 
     def handle_streaming_result(self, text: str, is_final: bool):
         if is_final:
+            self._last_preview_text = text
+            self._preview_active = False
             if self._streaming_display_active:
                 print(f"\r   {text:<70}")
                 self._streaming_display_active = False
+            if self.preview_show_tooltip:
+                self.system_tray.update_tooltip_preview(None)
+            if self.preview_show_overlay and self.preview_overlay:
+                self.preview_overlay.update_text(text)
+                threading.Timer(2.0, self.preview_overlay.hide).start()
         else:
+            self._last_preview_text = text
+            self._preview_active = True
             display_text = text if len(text) < 67 else "..." + text[-64:]
             print(f"\r   {display_text:<70}", end="", flush=True)
             self._streaming_display_active = True
+            if self.preview_show_tooltip:
+                self.system_tray.update_tooltip_preview(text)
+            if self.preview_show_overlay and self.preview_overlay:
+                self.preview_overlay.update_text(text)
+
+    def get_last_preview_text(self) -> dict:
+        return {
+            "text": self._last_preview_text,
+            "active": self._preview_active,
+        }
 
     def _clear_streaming_display(self):
         if self._streaming_display_active:

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -83,6 +83,8 @@ class StateManager:
         self._ensure_audio_device_for_host(self._current_audio_host)
     
     def handle_continuous_audio(self, audio_data):
+        if self.realtime_preview:
+            self.realtime_preview.deactivate()
         self._transcription_pipeline(audio_data, use_auto_enter=False)
         if self.listening_mode == ListeningMode.CONTINUOUS:
             print("   [CONTINUOUS] listening for speech...")
@@ -146,6 +148,8 @@ class StateManager:
         currently_recording = self.audio_recorder.get_recording_status()
 
         if currently_recording:
+            if self.realtime_preview:
+                self.realtime_preview.deactivate()
             self._clear_streaming_display()
             audio_data = self.audio_recorder.stop_recording()
             self._transcription_pipeline(audio_data, use_auto_enter)
@@ -154,6 +158,8 @@ class StateManager:
             return False
     
     def cancel_active_recording(self):
+        if self.realtime_preview:
+            self.realtime_preview.deactivate()
         self._clear_streaming_display()
         self._command_mode = False
         self.audio_recorder.cancel_recording()
@@ -206,6 +212,8 @@ class StateManager:
             self.config_manager.print_stop_instructions_based_on_config()
             self.audio_feedback.play_start_sound()
             self.system_tray.update_state("recording")
+            if self.preview_enabled and self.realtime_preview:
+                self.realtime_preview.activate()
     
     def _transcription_pipeline(self, audio_data, use_auto_enter: bool = False):
         try:
@@ -308,15 +316,11 @@ class StateManager:
             print("   [WAKE WORD] engine not available — falling back to hotkey mode")
 
     def set_preview_enabled(self, enabled: bool):
-        old = self.preview_enabled
         self.preview_enabled = enabled
         self.config_manager.update_listening_preview(enabled)
         self.logger.info(f"Preview {'enabled' if enabled else 'disabled'}")
-        if self.realtime_preview:
-            if enabled and not old:
-                self.realtime_preview.activate()
-            elif not enabled and old:
-                self.realtime_preview.deactivate()
+        if self.realtime_preview and not enabled:
+            self.realtime_preview.deactivate()
 
     def set_overlay_enabled(self, enabled: bool):
         self.preview_show_overlay = enabled

--- a/src/whisper_key/state_manager.py
+++ b/src/whisper_key/state_manager.py
@@ -121,7 +121,9 @@ class StateManager:
                 self.system_tray.update_tooltip_preview(None)
             if self.preview_show_overlay and self.preview_overlay:
                 self.preview_overlay.update_text(text)
-                threading.Timer(2.0, self.preview_overlay.hide).start()
+                hide_delay = self.config_manager.get_overlay_config().get('hide_after_sec', 3.0)
+                if hide_delay > 0:
+                    threading.Timer(hide_delay, self.preview_overlay.hide).start()
         else:
             self._last_preview_text = text
             self._preview_active = True

--- a/src/whisper_key/system_tray.py
+++ b/src/whisper_key/system_tray.py
@@ -358,6 +358,19 @@ class SystemTray:
         except Exception as e:
             self.logger.error(f"Failed to update tray icon: {e}")
 
+    def update_tooltip_preview(self, text):
+        if not TRAY_AVAILABLE or not self.is_running or not self.icon:
+            return
+
+        try:
+            if text:
+                truncated = text[:120]
+                self.icon.title = f"Whisper Key: {truncated}"
+            else:
+                self.icon.title = "Whisper Key"
+        except Exception as e:
+            self.logger.error(f"Failed to update tooltip: {e}")
+
     def refresh_menu(self):
         if not self.icon:
             return

--- a/src/whisper_key/system_tray.py
+++ b/src/whisper_key/system_tray.py
@@ -8,6 +8,12 @@ from .utils import open_file
 from .platform import permissions, icons
 
 try:
+    from .platform import monitors as _monitors
+    _MONITORS_AVAILABLE = True
+except ImportError:
+    _MONITORS_AVAILABLE = False
+
+try:
     import pystray
     from PIL import Image
     TRAY_AVAILABLE = True
@@ -202,6 +208,8 @@ class SystemTray:
 
             voice_commands_enabled = self.config_manager.get_setting('voice_commands', 'enabled')
 
+            preview_submenu = self._build_preview_submenu(preview_on)
+
             menu_items = [
                 pystray.MenuItem("Open log file...", self._open_log_file),
                 pystray.MenuItem("Open model cache...", self._open_model_cache),
@@ -230,8 +238,7 @@ class SystemTray:
                 ),
                 pystray.MenuItem(
                     "Preview",
-                    lambda icon, item: self._toggle_preview(),
-                    checked=lambda item: preview_on,
+                    pystray.Menu(*preview_submenu),
                 ),
             ]
 
@@ -323,6 +330,106 @@ class SystemTray:
             self.icon.menu = self._create_menu()
         except Exception as e:
             self.logger.error(f"Error toggling preview: {e}")
+
+    def _build_preview_submenu(self, preview_on: bool) -> list:
+        overlay_config = self.config_manager.get_overlay_config()
+        show_overlay = self.state_manager.preview_show_overlay
+        current_monitor = overlay_config.get('monitor', 'follow_focus')
+        current_position = overlay_config.get('position', 'bottom_center')
+
+        items = [
+            pystray.MenuItem(
+                "Enabled",
+                lambda icon, item: self._toggle_preview(),
+                checked=lambda item: self.state_manager.preview_enabled,
+            ),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem(
+                "Overlay",
+                pystray.Menu(*self._build_overlay_submenu(show_overlay, current_monitor, current_position)),
+            ),
+        ]
+        return items
+
+    def _build_overlay_submenu(self, show_overlay: bool, current_monitor, current_position: str) -> list:
+        def make_monitor_selector(value):
+            return lambda icon, item: self._set_overlay_monitor(value)
+
+        def make_is_monitor(value):
+            return lambda item: current_monitor == value
+
+        def make_position_selector(value):
+            return lambda icon, item: self._set_overlay_position(value)
+
+        def make_is_position(value):
+            return lambda item: current_position == value
+
+        monitor_items = [
+            pystray.MenuItem("Follow Focus", make_monitor_selector("follow_focus"), radio=True, checked=make_is_monitor("follow_focus")),
+            pystray.MenuItem("Cursor Position", make_monitor_selector("cursor"), radio=True, checked=make_is_monitor("cursor")),
+            pystray.MenuItem("Primary Monitor", make_monitor_selector("primary"), radio=True, checked=make_is_monitor("primary")),
+            pystray.MenuItem("All Monitors", make_monitor_selector("all"), radio=True, checked=make_is_monitor("all")),
+        ]
+
+        if _MONITORS_AVAILABLE:
+            try:
+                hw_monitors = _monitors.enumerate_monitors()
+                if len(hw_monitors) > 1:
+                    monitor_items.append(pystray.Menu.SEPARATOR)
+                    for m in hw_monitors:
+                        label = f"Monitor {m.index} ({m.name})" if m.name else f"Monitor {m.index}"
+                        monitor_items.append(pystray.MenuItem(
+                            label,
+                            make_monitor_selector(m.index),
+                            radio=True,
+                            checked=make_is_monitor(m.index),
+                        ))
+            except Exception as e:
+                self.logger.debug(f"Could not enumerate monitors for tray: {e}")
+
+        position_choices = [
+            ("Bottom Center", "bottom_center"),
+            ("Top Center", "top_center"),
+            ("Bottom Left", "bottom_left"),
+            ("Bottom Right", "bottom_right"),
+        ]
+        position_items = [
+            pystray.MenuItem(label, make_position_selector(value), radio=True, checked=make_is_position(value))
+            for label, value in position_choices
+        ]
+
+        return [
+            pystray.MenuItem(
+                "Show Overlay",
+                lambda icon, item: self._toggle_overlay(),
+                checked=lambda item: self.state_manager.preview_show_overlay,
+            ),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Monitor", pystray.Menu(*monitor_items)),
+            pystray.MenuItem("Position", pystray.Menu(*position_items)),
+        ]
+
+    def _toggle_overlay(self):
+        try:
+            new_state = not self.state_manager.preview_show_overlay
+            self.state_manager.set_overlay_enabled(new_state)
+            self.icon.menu = self._create_menu()
+        except Exception as e:
+            self.logger.error(f"Error toggling overlay: {e}")
+
+    def _set_overlay_monitor(self, value):
+        try:
+            self.state_manager.set_overlay_monitor(value)
+            self.icon.menu = self._create_menu()
+        except Exception as e:
+            self.logger.error(f"Error setting overlay monitor: {e}")
+
+    def _set_overlay_position(self, value: str):
+        try:
+            self.state_manager.set_overlay_position(value)
+            self.icon.menu = self._create_menu()
+        except Exception as e:
+            self.logger.error(f"Error setting overlay position: {e}")
 
     def _select_audio_host(self, host_name: str):
         try:

--- a/src/whisper_key/system_tray.py
+++ b/src/whisper_key/system_tray.py
@@ -168,6 +168,38 @@ class SystemTray:
 
             model_sub_menu_items = self._build_model_menu_items(current_model, is_model_loading)
 
+            mode_info = self.state_manager.get_mode_info()
+            current_listening_mode = mode_info["mode"]
+            preview_on = mode_info["preview"]
+
+            def make_mode_selector(mode):
+                return lambda icon, item: self._select_listening_mode(mode)
+
+            def make_is_mode(mode_value):
+                return lambda item: current_listening_mode == mode_value
+
+            from .state_manager import ListeningMode
+            listening_mode_items = [
+                pystray.MenuItem(
+                    "Hotkey",
+                    make_mode_selector(ListeningMode.HOTKEY),
+                    radio=True,
+                    checked=make_is_mode("hotkey"),
+                ),
+                pystray.MenuItem(
+                    "Continuous",
+                    make_mode_selector(ListeningMode.CONTINUOUS),
+                    radio=True,
+                    checked=make_is_mode("continuous"),
+                ),
+                pystray.MenuItem(
+                    "Wake Word",
+                    make_mode_selector(ListeningMode.WAKE_WORD),
+                    radio=True,
+                    checked=make_is_mode("wake_word"),
+                ),
+            ]
+
             voice_commands_enabled = self.config_manager.get_setting('voice_commands', 'enabled')
 
             menu_items = [
@@ -191,6 +223,16 @@ class SystemTray:
                 pystray.MenuItem("Copy to clipboard", lambda icon, item: self._set_transcription_mode(False), radio=True, checked=lambda item: not auto_paste_enabled),
                 pystray.Menu.SEPARATOR,
                 pystray.MenuItem(f"Model: {current_model.title()}", pystray.Menu(*model_sub_menu_items)),
+                pystray.Menu.SEPARATOR,
+                pystray.MenuItem(
+                    "Listening Mode",
+                    pystray.Menu(*listening_mode_items),
+                ),
+                pystray.MenuItem(
+                    "Preview",
+                    lambda icon, item: self._toggle_preview(),
+                    checked=lambda item: preview_on,
+                ),
             ]
 
             menu_items.extend([
@@ -266,6 +308,21 @@ class SystemTray:
 
         except Exception as e:
             self.logger.error(f"Error selecting model {model_key}: {e}")
+
+    def _select_listening_mode(self, mode):
+        try:
+            self.state_manager.set_listening_mode(mode)
+            self.icon.menu = self._create_menu()
+        except Exception as e:
+            self.logger.error(f"Error selecting listening mode {mode.value}: {e}")
+
+    def _toggle_preview(self):
+        try:
+            new_state = not self.state_manager.preview_enabled
+            self.state_manager.set_preview_enabled(new_state)
+            self.icon.menu = self._create_menu()
+        except Exception as e:
+            self.logger.error(f"Error toggling preview: {e}")
 
     def _select_audio_host(self, host_name: str):
         try:

--- a/src/whisper_key/voice_activity_detection.py
+++ b/src/whisper_key/voice_activity_detection.py
@@ -190,10 +190,18 @@ class ContinuousVoiceDetector:
 
         try:
             audio_int16 = convert_audio_for_ten_vad(audio_chunk)
-            probability, _ = self.ten_vad.process(audio_int16)
-            speech_detected = self.hysteresis.detect_speech(probability)
-            self.probability_buffer.append(probability)
-            return self._update_state(speech_detected)
+            last_event = VadEvent.NO_EVENT
+            for i in range(0, len(audio_int16), VAD_CHUNK_SIZE):
+                sub_chunk = audio_int16[i:i + VAD_CHUNK_SIZE]
+                if len(sub_chunk) < VAD_CHUNK_SIZE:
+                    sub_chunk = np.pad(sub_chunk, (0, VAD_CHUNK_SIZE - len(sub_chunk)), mode='constant')
+                probability, _ = self.ten_vad.process(sub_chunk)
+                speech_detected = self.hysteresis.detect_speech(probability)
+                self.probability_buffer.append(probability)
+                event = self._update_state(speech_detected)
+                if event != VadEvent.NO_EVENT:
+                    last_event = event
+            return last_event
 
         except Exception as e:
             self.logger.error(f"Error processing VAD chunk: {e}")

--- a/src/whisper_key/wake_word.py
+++ b/src/whisper_key/wake_word.py
@@ -1,0 +1,234 @@
+import logging
+import threading
+import time
+from abc import ABC, abstractmethod
+from typing import Callable, Optional
+
+import numpy as np
+
+from .audio_stream import AudioStreamManager, WHISPER_SAMPLE_RATE, STREAM_CHUNK_SAMPLES
+from .voice_activity_detection import VadManager, convert_audio_for_ten_vad
+
+try:
+    import openwakeword
+    from openwakeword.model import Model as OwwModel
+    HAS_OPENWAKEWORD = True
+except ImportError:
+    OwwModel = None
+    HAS_OPENWAKEWORD = False
+
+try:
+    import pvporcupine
+    HAS_PORCUPINE = True
+except ImportError:
+    pvporcupine = None
+    HAS_PORCUPINE = False
+
+
+class WakeWordEngine(ABC):
+    @property
+    @abstractmethod
+    def chunk_samples(self) -> int:
+        ...
+
+    @abstractmethod
+    def predict(self, audio_int16: np.ndarray) -> bool:
+        ...
+
+    @abstractmethod
+    def reset(self):
+        ...
+
+    @abstractmethod
+    def cleanup(self):
+        ...
+
+
+class OpenWakeWordEngine(WakeWordEngine):
+    CHUNK_SAMPLES = 1280
+
+    def __init__(self, model_paths=None, threshold: float = 0.5):
+        self.threshold = threshold
+        self.logger = logging.getLogger(__name__)
+
+        if not HAS_OPENWAKEWORD:
+            raise ImportError("openwakeword is not installed")
+
+        inference_framework = "onnx"
+        kwargs = {"inference_framework": inference_framework}
+        if model_paths:
+            kwargs["wakeword_models"] = model_paths
+
+        self._model = OwwModel(**kwargs)
+        self.logger.info(f"OpenWakeWord engine initialized (models: {list(self._model.models.keys())})")
+
+    @property
+    def chunk_samples(self) -> int:
+        return self.CHUNK_SAMPLES
+
+    def predict(self, audio_int16: np.ndarray) -> bool:
+        prediction = self._model.predict(audio_int16)
+        for model_name, score in prediction.items():
+            if score >= self.threshold:
+                self.logger.info(f"Wake word detected: {model_name} (score={score:.3f})")
+                return True
+        return False
+
+    def reset(self):
+        self._model.reset()
+
+    def cleanup(self):
+        pass
+
+
+class PorcupineEngine(WakeWordEngine):
+    CHUNK_SAMPLES = 512
+
+    def __init__(self, access_key: str, keyword_paths=None, keywords=None, sensitivities=None):
+        self.logger = logging.getLogger(__name__)
+
+        if not HAS_PORCUPINE:
+            raise ImportError("pvporcupine is not installed")
+
+        kwargs = {"access_key": access_key}
+        if keyword_paths:
+            kwargs["keyword_paths"] = keyword_paths
+        elif keywords:
+            kwargs["keywords"] = keywords
+        else:
+            kwargs["keywords"] = ["porcupine"]
+
+        if sensitivities:
+            kwargs["sensitivities"] = sensitivities
+
+        self._handle = pvporcupine.create(**kwargs)
+        self.logger.info("Porcupine engine initialized")
+
+    @property
+    def chunk_samples(self) -> int:
+        return self.CHUNK_SAMPLES
+
+    def predict(self, audio_int16: np.ndarray) -> bool:
+        result = self._handle.process(audio_int16)
+        if result >= 0:
+            self.logger.info(f"Porcupine wake word detected (index={result})")
+            return True
+        return False
+
+    def reset(self):
+        pass
+
+    def cleanup(self):
+        if self._handle:
+            self._handle.delete()
+            self._handle = None
+
+
+class WakeWordManager:
+    def __init__(self,
+                 audio_stream_manager: AudioStreamManager,
+                 vad_manager: VadManager,
+                 engine: WakeWordEngine,
+                 on_wake_word: Callable[[], None],
+                 is_busy: Callable[[], bool],
+                 cooldown_sec: float = 2.0,
+                 vad_pre_filter: bool = True):
+
+        self.audio_stream_manager = audio_stream_manager
+        self.vad_manager = vad_manager
+        self.engine = engine
+        self.on_wake_word = on_wake_word
+        self.is_busy = is_busy
+        self.cooldown_sec = cooldown_sec
+        self.vad_pre_filter = vad_pre_filter and vad_manager.is_available()
+
+        self.logger = logging.getLogger(__name__)
+        self._active = False
+        self._last_trigger_time: float = 0
+        self._chunk_accumulator: np.ndarray = np.array([], dtype=np.int16)
+
+        self._onset_threshold = vad_manager.vad_onset_threshold
+        self._speech_detected = False
+
+    def _detect_speech_vad(self, audio_int16: np.ndarray) -> bool:
+        try:
+            probability, _ = self.vad_manager.ten_vad.process(audio_int16)
+            if self._speech_detected:
+                self._speech_detected = probability > self.vad_manager.vad_offset_threshold
+            else:
+                self._speech_detected = probability > self._onset_threshold
+            return self._speech_detected
+        except Exception:
+            return True
+
+    def activate(self):
+        if self._active:
+            return
+
+        self._active = True
+        self._chunk_accumulator = np.array([], dtype=np.int16)
+        self._speech_detected = False
+        self.engine.reset()
+        self.audio_stream_manager.add_consumer(self._on_audio_chunk)
+        self.logger.info("Wake word manager activated")
+        print("   [WAKE WORD] listening for wake word...")
+
+    def deactivate(self):
+        if not self._active:
+            return
+
+        self._active = False
+        self.audio_stream_manager.remove_consumer(self._on_audio_chunk)
+        self._chunk_accumulator = np.array([], dtype=np.int16)
+        self._speech_detected = False
+        self.logger.info("Wake word manager deactivated")
+
+    def _on_audio_chunk(self, audio_data):
+        if not self._active:
+            return
+
+        if self.is_busy():
+            return
+
+        if self.audio_stream_manager.needs_resampling():
+            chunk_16k = self.audio_stream_manager.resample_to_whisper(audio_data)
+        else:
+            chunk_16k = audio_data
+
+        audio_int16 = convert_audio_for_ten_vad(chunk_16k)
+
+        if self.vad_pre_filter and not self._detect_speech_vad(audio_int16):
+            self._chunk_accumulator = np.array([], dtype=np.int16)
+            return
+
+        target_samples = self.engine.chunk_samples
+
+        if len(audio_int16) == target_samples:
+            self._process_engine_chunk(audio_int16)
+        else:
+            self._chunk_accumulator = np.concatenate([self._chunk_accumulator, audio_int16])
+            while len(self._chunk_accumulator) >= target_samples:
+                engine_chunk = self._chunk_accumulator[:target_samples]
+                self._chunk_accumulator = self._chunk_accumulator[target_samples:]
+                self._process_engine_chunk(engine_chunk)
+
+    def _process_engine_chunk(self, audio_int16: np.ndarray):
+        now = time.time()
+        if now - self._last_trigger_time < self.cooldown_sec:
+            return
+
+        if self.engine.predict(audio_int16):
+            self._last_trigger_time = now
+            self.engine.reset()
+            self._chunk_accumulator = np.array([], dtype=np.int16)
+            self.logger.info("Wake word triggered")
+            print("\n🔊 Wake word detected!")
+            threading.Thread(target=self.on_wake_word, daemon=True).start()
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def cleanup(self):
+        self.deactivate()
+        self.engine.cleanup()

--- a/src/whisper_key/whisper_engine.py
+++ b/src/whisper_key/whisper_engine.py
@@ -34,6 +34,7 @@ class WhisperEngine:
 
         self._loading_thread = None
         self._progress_callback = None
+        self._transcribe_lock = threading.Lock()
 
         self.vad_manager = vad_manager
 
@@ -136,69 +137,97 @@ class WhisperEngine:
                          audio_data: np.ndarray) -> Optional[str]:
         if self.model is None:
             return None
-        
+
         if audio_data is None or len(audio_data) == 0:
             self.logger.warning("No audio data to transcribe")
             return None
-        
-        try:
-            speech_detected = True
-            if self.vad_manager and self.vad_manager.is_available():
-                speech_detected = self.vad_manager.check_audio_for_speech(audio_data)
-            
-            if not speech_detected:
-                print("   ✗ No speech detected, skipping transcription")
+
+        with self._transcribe_lock:
+            try:
+                speech_detected = True
+                if self.vad_manager and self.vad_manager.is_available():
+                    speech_detected = self.vad_manager.check_audio_for_speech(audio_data)
+
+                if not speech_detected:
+                    print("   ✗ No speech detected, skipping transcription")
+                    return None
+
+                start_time = time.time()
+
+                if len(audio_data.shape) > 1:
+                    audio_data = audio_data.flatten()
+
+                audio_data = audio_data.astype(np.float32)
+
+                transcribe_kwargs = dict(
+                    beam_size=self.beam_size,
+                    language=self.language,
+                    condition_on_previous_text=False,
+                )
+                if self.initial_prompt:
+                    transcribe_kwargs["initial_prompt"] = self.initial_prompt
+                if self.hotwords:
+                    transcribe_kwargs["hotwords"] = self.hotwords
+
+                segments, info = self.model.transcribe(audio_data, **transcribe_kwargs)
+
+                transcribed_text = ""
+                for segment in segments:
+                    transcribed_text += segment.text
+
+                transcribed_text = transcribed_text.strip()
+
+                end_time = time.time()
+                transcription_time = end_time - start_time
+                print(f"   ✓ Transcription completed in {transcription_time:.1f} seconds")
+
+                detected_language = info.language
+                confidence = info.language_probability
+                self.logger.info(f"Transcription complete. Language: {detected_language} (confidence: {confidence:.2f}) - Time: {transcription_time:.2f}s")
+                if self.log_transcriptions:
+                    self.logger.info(f"Transcribed text: '{transcribed_text}'")
+                else:
+                    self.logger.info(f"Transcribed {len(transcribed_text)} chars")
+
+                if transcribed_text:
+                    print(f"   ✓ Transcribed: '{transcribed_text}'")
+                    return transcribed_text
+                else:
+                    self.logger.info("Transcription was empty")
+                    return None
+
+            except Exception as e:
+                self.logger.error(f"Transcription failed: {e}")
                 return None
-                       
-            start_time = time.time() # Time transcription for user feedback
-            
-            # Prep audio for faster-whisper
+
+    def transcribe_preview(self, audio_data: np.ndarray) -> Optional[str]:
+        if self.model is None:
+            return None
+
+        acquired = self._transcribe_lock.acquire(timeout=0.1)
+        if not acquired:
+            return None
+
+        try:
             if len(audio_data.shape) > 1:
                 audio_data = audio_data.flatten()
-            
             audio_data = audio_data.astype(np.float32)
-            
-            transcribe_kwargs = dict(
-                beam_size=self.beam_size,
+
+            segments, _ = self.model.transcribe(
+                audio_data,
+                beam_size=1,
                 language=self.language,
                 condition_on_previous_text=False,
             )
-            if self.initial_prompt:
-                transcribe_kwargs["initial_prompt"] = self.initial_prompt
-            if self.hotwords:
-                transcribe_kwargs["hotwords"] = self.hotwords
 
-            segments, info = self.model.transcribe(audio_data, **transcribe_kwargs)
-            
-            transcribed_text = ""
-            for segment in segments:
-                transcribed_text += segment.text
-            
-            transcribed_text = transcribed_text.strip()
-            
-            end_time = time.time()
-            transcription_time = end_time - start_time
-            print(f"   ✓ Transcription completed in {transcription_time:.1f} seconds")
-            
-            # Log some info about what we transcribed
-            detected_language = info.language
-            confidence = info.language_probability
-            self.logger.info(f"Transcription complete. Language: {detected_language} (confidence: {confidence:.2f}) - Time: {transcription_time:.2f}s")
-            if self.log_transcriptions:
-                self.logger.info(f"Transcribed text: '{transcribed_text}'")
-            else:
-                self.logger.info(f"Transcribed {len(transcribed_text)} chars")
-            
-            if transcribed_text:
-                print(f"   ✓ Transcribed: '{transcribed_text}'")
-                return transcribed_text
-            else:
-                self.logger.info("Transcription was empty")
-                return None
-                
+            text = "".join(segment.text for segment in segments).strip()
+            return text if text else None
+
         except Exception as e:
-            self.logger.error(f"Transcription failed: {e}")
+            self.logger.error(f"Preview transcription failed: {e}")
             return None
+        finally:
+            self._transcribe_lock.release()
     
     
     def change_model(self,


### PR DESCRIPTION
## Summary

Adds a lightweight HTTP server directly into whisper-key that exposes the StateManager API over HTTP. This allows remote control of recording from VMs, other machines, or scripts — without simulating keyboard hotkeys.

**Why:** Simulated keystrokes (`keybd_event`, `SendInput`) are unreliable when the app runs in the background or when triggered from a VMware guest. The HTTP trigger calls `StateManager.start_recording()` / `stop_recording()` directly — 100% reliable.

## Changes

### New file: `http_trigger.py`
- Lightweight `HTTPServer` running in a daemon thread (port 5757, configurable)
- 6 endpoints calling StateManager directly:

| Endpoint | Action |
|---|---|
| `GET /record` | Start recording |
| `GET /stop` | Stop + transcribe (returns text in response!) |
| `GET /toggle` | Start if idle, stop if recording |
| `GET /cancel` | Cancel active recording |
| `GET /command` | Voice command mode |
| `GET /status` | Current state (idle/recording/processing) |

- JSON responses with CORS headers
- `/stop` and `/toggle` return the transcribed text in the `text` field — enables VM clipboard integration
- State-aware: returns 409 on invalid transitions (e.g., record while processing)

### Modified: `main.py`
- Creates and starts `HttpTrigger` after `state_manager.attach_components()`
- Reads config from `http_trigger` section
- Shows HTTP port in startup output

### Modified: `config.defaults.yaml`
- New `http_trigger` section:
```yaml
http_trigger:
  enabled: true
  port: 5757
  host: "0.0.0.0"
```

## Use Cases

**From a VM (e.g., Arch Linux in VMware):**
```bash
curl http://192.168.31.1:5757/toggle    # start recording
# speak...
curl http://192.168.31.1:5757/toggle    # stop + get text
```

**Scripting / automation:**
```bash
TEXT=$(curl -s http://localhost:5757/stop | jq -r .text)
echo "$TEXT" | wl-copy  # paste in Wayland VM
```

**Status monitoring:**
```bash
curl http://localhost:5757/status
# {"ok": true, "state": "idle"}
```

## Design Decisions

- **Daemon thread** — doesn't block the main event loop
- **StateManager directly** — no hotkey simulation, no keyboard hooks
- **JSON responses** — easy to parse from any language/script
- **CORS headers** — usable from browser extensions
- **Graceful failure** — if port is busy, logs warning and continues without HTTP

## Test plan

- [x] `curl /status` returns idle state
- [x] `curl /record` starts recording (sound plays, tray updates)
- [x] `curl /stop` returns transcribed text in JSON
- [x] `curl /toggle` works as start/stop cycle
- [x] `curl /cancel` cancels active recording
- [x] Hotkey mode still works alongside HTTP trigger
- [x] App starts normally if port 5757 is already in use

🤖 Generated with [Claude Code](https://claude.com/claude-code)