### PR TITLE
Add console window management with start_hidden and minimize-to-tray

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -12,4 +12,4 @@ allowed-tools: Bash(git *), Bash(gh *)
 7. Build for PyPI: `powershell.exe -Command "cd [WSL_PROJECT_PATH]; python -m build"`
 8. Upload to PyPI: `powershell.exe -Command "twine upload [WSL_PROJECT_PATH]\\dist\\*"`
 9. Build pyapp exe: `/build-pyapp-exe` (depends on PyPI package being available)
-10. Upload exe to release: `gh release upload [VERSION] [PATH_TO_EXE]`
+10. Upload both exes to release: `gh release upload [VERSION] [PATH_TO_WHISPER_KEY_EXE] [PATH_TO_WHISPER_KEY_HIDEABLE_EXE]`

--- a/pyapp-build/build-pyapp.ps1
+++ b/pyapp-build/build-pyapp.ps1
@@ -90,6 +90,7 @@ $env:PYAPP_PYTHON_VERSION = "3.12"
 $env:PYAPP_EXEC_CODE = 'from whisper_key.main import main; main()'
 $env:PYAPP_SELF_COMMAND = "self"
 $env:PYAPP_PASS_LOCATION = "true"
+$env:PYAPP_IS_GUI = "true"
 
 if ($Clean) {
     $TargetDir = Join-Path $PyAppSourcePath "target"
@@ -127,3 +128,4 @@ Remove-Item Env:\PYAPP_PYTHON_VERSION -ErrorAction SilentlyContinue
 Remove-Item Env:\PYAPP_EXEC_CODE -ErrorAction SilentlyContinue
 Remove-Item Env:\PYAPP_SELF_COMMAND -ErrorAction SilentlyContinue
 Remove-Item Env:\PYAPP_PASS_LOCATION -ErrorAction SilentlyContinue
+Remove-Item Env:\PYAPP_IS_GUI -ErrorAction SilentlyContinue

--- a/pyapp-build/build-pyapp.ps1
+++ b/pyapp-build/build-pyapp.ps1
@@ -90,7 +90,6 @@ $env:PYAPP_PYTHON_VERSION = "3.12"
 $env:PYAPP_EXEC_CODE = 'from whisper_key.main import main; main()'
 $env:PYAPP_SELF_COMMAND = "self"
 $env:PYAPP_PASS_LOCATION = "true"
-$env:PYAPP_IS_GUI = "true"
 
 if ($Clean) {
     $TargetDir = Join-Path $PyAppSourcePath "target"
@@ -100,28 +99,40 @@ if ($Clean) {
     }
 }
 
-Push-Location $PyAppSourcePath
-Write-Host "Running cargo build --release..." -ForegroundColor Yellow
-cargo build --release
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "Build failed!" -ForegroundColor Red
-    exit 1
-}
-
 if (-not (Test-Path $DistPath)) {
     New-Item -ItemType Directory -Path $DistPath -Force | Out-Null
 }
 
-$SourceExe = Join-Path $PyAppSourcePath "target\release\pyapp.exe"
-$DestExe = Join-Path $DistPath "$AppName.exe"
-Copy-Item $SourceExe $DestExe -Force
+$Builds = @(
+    @{ Name = "$AppName";      IsGui = $false; Label = "console" },
+    @{ Name = "$AppName-hideable"; IsGui = $true;  Label = "hideable (GUI subsystem)" }
+)
 
-$ExeSize = (Get-Item $DestExe).Length / 1MB
-Write-Host "Build successful!" -ForegroundColor Green
-Write-Host "Executable: $DestExe" -ForegroundColor Green
-Write-Host ("Size: {0:N2} MB" -f $ExeSize) -ForegroundColor Green
+Push-Location $PyAppSourcePath
+
+foreach ($Build in $Builds) {
+    Write-Host "`nBuilding $($Build.Label): $($Build.Name).exe..." -ForegroundColor Yellow
+
+    if ($Build.IsGui) { $env:PYAPP_IS_GUI = "true" }
+    else { Remove-Item Env:\PYAPP_IS_GUI -ErrorAction SilentlyContinue }
+
+    cargo build --release
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Build failed for $($Build.Name)!" -ForegroundColor Red
+        exit 1
+    }
+
+    $SourceExe = Join-Path $PyAppSourcePath "target\release\pyapp.exe"
+    $DestExe = Join-Path $DistPath "$($Build.Name).exe"
+    Copy-Item $SourceExe $DestExe -Force
+
+    $ExeSize = (Get-Item $DestExe).Length / 1MB
+    Write-Host ("  -> $DestExe ({0:N2} MB)" -f $ExeSize) -ForegroundColor Green
+}
 
 Pop-Location
+Write-Host "`nBuild complete!" -ForegroundColor Green
+
 Remove-Item Env:\PYAPP_PROJECT_NAME -ErrorAction SilentlyContinue
 Remove-Item Env:\PYAPP_PROJECT_VERSION -ErrorAction SilentlyContinue
 Remove-Item Env:\PYAPP_PYTHON_VERSION -ErrorAction SilentlyContinue

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -9,332 +9,318 @@
 # macOS: ~/.whisperkey/user_settings.yaml
 
 whisper: # Whisper AI Model Settings
+    # Model selection
+    # See "models" below for more information
+    model: tiny
 
-  # Model selection
-  # See "models" below for more information
-  model: tiny
-  
-  # Transcription device
-  # Options: cpu, cuda (for both NVIDIA and AMD)
-  # For GPU setup, see https://github.com/PinW/whisper-key-local/blob/master/docs/gpu-setup.md
-  device: cpu
+    # Transcription device
+    # Options: cpu, cuda (for both NVIDIA and AMD)
+    # For GPU setup, see https://github.com/PinW/whisper-key-local/blob/master/docs/gpu-setup.md
+    device: cpu
 
-  # Compute Precision
-  # Options: int8, float16, float32
-  compute_type: int8
-  
-  # Language detection
-  # Options: auto (auto-detect), en, es, fr, de, etc.
-  # Set to specific language code to force language, or auto for auto-detection
-  language: auto
-  
-  # Transcription quality settings
-  beam_size: 5  # Higher = more accurate but slower (1-10)
+    # Compute Precision
+    # Options: int8, float16, float32
+    compute_type: int8
 
-  # Initial prompt to guide transcription style, language variant, or script
-  initial_prompt: ""
+    # Language detection
+    # Options: auto (auto-detect), en, es, fr, de, etc.
+    # Set to specific language code to force language, or auto for auto-detection
+    language: auto
 
-  # Custom hotwords — words the model should favor during transcription
-  # Useful for names, technical terms, or domain-specific vocabulary
-  # Example: ["CTranslate2", "PyInstaller", "Whisper Key"]
-  hotwords: []
+    # Transcription quality settings
+    beam_size: 5 # Higher = more accurate but slower (1-10)
 
-  # Available models (set enabled: false to hide from menu)
-  # To add custom models (CTranslate2 format), add entry with source (HuggingFace or local path)
-  # Example: my-model: {source: "username/repo-ct2", label: "My Model", group: custom}
-  models:
-    # Official whisper models
-    tiny:
-      label: "Tiny (75MB)"
-      group: official
-      enabled: true
-    base:
-      label: "Base (141MB)"
-      group: official
-      enabled: true
-    small:
-      label: "Small (464MB)"
-      group: official
-      enabled: true
-    medium:
-      label: "Medium (1.4GB)"
-      group: official
-      enabled: true
-    large: # Uses the large-v3 version
-      label: "Large (2.9GB)"
-      group: official
-      enabled: true
-    large-v3-turbo: # 8x faster and only slightly less accurate (transcription optimized)
-      label: "Large-V3-Turbo (1.5GB)"
-      group: official
-      enabled: true
+    # Initial prompt to guide transcription style, language variant, or script
+    initial_prompt: ""
 
-    # English-only models — same architecture as above, trained exclusively on English
-    tiny.en:
-      label: "Tiny.En (English, 74MB)"
-      group: custom
-      enabled: true
-    base.en:
-      label: "Base.En (English, 141MB)"
-      group: custom
-      enabled: true
-    small.en:
-      label: "Small.En (English, 464MB)"
-      group: custom
-      enabled: true
-    medium.en:
-      label: "Medium.En (English, 1.5GB)"
-      group: custom
-      enabled: true
+    # Custom hotwords — words the model should favor during transcription
+    # Useful for names, technical terms, or domain-specific vocabulary
+    # Example: ["CTranslate2", "PyInstaller", "Whisper Key"]
+    hotwords: []
 
-    # Distilled models — smaller and faster than standard Whisper, English only
-    distil-small.en:
-      source: Systran/faster-distil-whisper-small.en
-      label: "Distil-Small.En (English, 320MB)"
-      group: custom
-      enabled: true
-    distil-medium.en:
-      source: Systran/faster-distil-whisper-medium.en
-      label: "Distil-Medium.En (English, 755MB)"
-      group: custom
-      enabled: true
-    distil-large-v3.5: # ~1.5x faster than Large-V3-Turbo with comparable accuracy
-      source: distil-whisper/distil-large-v3.5-ct2
-      label: "Distil-Large-V3.5 (English, 1.4GB)"
-      group: custom
-      enabled: true
+    # Available models (set enabled: false to hide from menu)
+    # To add custom models (CTranslate2 format), add entry with source (HuggingFace or local path)
+    # Example: my-model: {source: "username/repo-ct2", label: "My Model", group: custom}
+    models:
+        # Official whisper models
+        tiny:
+            label: "Tiny (75MB)"
+            group: official
+            enabled: true
+        base:
+            label: "Base (141MB)"
+            group: official
+            enabled: true
+        small:
+            label: "Small (464MB)"
+            group: official
+            enabled: true
+        medium:
+            label: "Medium (1.4GB)"
+            group: official
+            enabled: true
+        large: # Uses the large-v3 version
+            label: "Large (2.9GB)"
+            group: official
+            enabled: true
+        large-v3-turbo: # 8x faster and only slightly less accurate (transcription optimized)
+            label: "Large-V3-Turbo (1.5GB)"
+            group: official
+            enabled: true
+
+        # English-only models — same architecture as above, trained exclusively on English
+        tiny.en:
+            label: "Tiny.En (English, 74MB)"
+            group: custom
+            enabled: true
+        base.en:
+            label: "Base.En (English, 141MB)"
+            group: custom
+            enabled: true
+        small.en:
+            label: "Small.En (English, 464MB)"
+            group: custom
+            enabled: true
+        medium.en:
+            label: "Medium.En (English, 1.5GB)"
+            group: custom
+            enabled: true
+
+        # Distilled models — smaller and faster than standard Whisper, English only
+        distil-small.en:
+            source: Systran/faster-distil-whisper-small.en
+            label: "Distil-Small.En (English, 320MB)"
+            group: custom
+            enabled: true
+        distil-medium.en:
+            source: Systran/faster-distil-whisper-medium.en
+            label: "Distil-Medium.En (English, 755MB)"
+            group: custom
+            enabled: true
+        distil-large-v3.5: # ~1.5x faster than Large-V3-Turbo with comparable accuracy
+            source: distil-whisper/distil-large-v3.5-ct2
+            label: "Distil-Large-V3.5 (English, 1.4GB)"
+            group: custom
+            enabled: true
 
 streaming: # Real-time STT (Experimental, speech preview only)
+    # Real-time streaming speech recognition using sherpa-onnx
+    streaming_enabled: false
 
-  # Real-time streaming speech recognition using sherpa-onnx
-  streaming_enabled: false
+    # Streaming model type
+    streaming_model: zipformer.tiny.en
 
-  # Streaming model type
-  streaming_model: zipformer.tiny.en
-
-  # Available streaming models
-  # Requires sherpa-onnx streaming transducer models (e.g., Zipformer)
-  # Browse models: https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html
-  models:
-    zipformer.tiny.en:
-      source: csukuangfj/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17
-      label: "Zipformer English Tiny (20MB)"
-      files:
-        encoder: encoder-epoch-99-avg-1.int8.onnx
-        decoder: decoder-epoch-99-avg-1.int8.onnx
-        joiner: joiner-epoch-99-avg-1.int8.onnx
-        tokens: tokens.txt
+    # Available streaming models
+    # Requires sherpa-onnx streaming transducer models (e.g., Zipformer)
+    # Browse models: https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html
+    models:
+        zipformer.tiny.en:
+            source: csukuangfj/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17
+            label: "Zipformer English Tiny (20MB)"
+            files:
+                encoder: encoder-epoch-99-avg-1.int8.onnx
+                decoder: decoder-epoch-99-avg-1.int8.onnx
+                joiner: joiner-epoch-99-avg-1.int8.onnx
+                tokens: tokens.txt
 
 hotkey: # Hotkey Configuration
+    # Key combination to start recording
+    # Format: modifier+modifier+key (use lowercase)
+    # Windows modifiers: ctrl, shift, alt, win
+    # macOS modifiers: cmd, ctrl, shift, option, fn
+    # Examples:
+    #   - "ctrl+win"      (Windows default)
+    #   - "fn+ctrl"       (macOS default)
+    #   - "ctrl+alt+r"
+    #   - "win+v"
+    #   - "ctrl+shift+f12"
+    recording_hotkey: "ctrl+win | macos: fn+ctrl"
 
-  # Key combination to start recording
-  # Format: modifier+modifier+key (use lowercase)
-  # Windows modifiers: ctrl, shift, alt, win
-  # macOS modifiers: cmd, ctrl, shift, option, fn
-  # Examples:
-  #   - "ctrl+win"      (Windows default)
-  #   - "fn+ctrl"       (macOS default)
-  #   - "ctrl+alt+r"
-  #   - "win+v"
-  #   - "ctrl+shift+f12"
-  recording_hotkey: "ctrl+win | macos: fn+ctrl"
+    # Key to stop recording (shared between transcription and command modes)
+    stop_key: "ctrl | macos: fn"
 
-  # Key to stop recording (shared between transcription and command modes)
-  stop_key: "ctrl | macos: fn"
+    # Alternative stop key that also sends ENTER after pasting
+    # Only works when auto-paste is enabled
+    auto_send_key: "alt | macos: option"
 
-  # Alternative stop key that also sends ENTER after pasting
-  # Only works when auto-paste is enabled
-  auto_send_key: "alt | macos: option"
-  
-  # Key combination to cancel recording
-  # Format: modifier+modifier+key (use lowercase) or single key
-  # Examples: "esc", "ctrl+c", "shift+esc"
-  # Note: On macOS, ESC is system-reserved
-  cancel_combination: "esc | macos: shift"
+    # Key combination to cancel recording
+    # Format: modifier+modifier+key (use lowercase) or single key
+    # Examples: "esc", "ctrl+c", "shift+esc"
+    # Note: On macOS, ESC is system-reserved
+    cancel_combination: "esc | macos: shift"
 
-  # Recording mode
-  # "toggle" = press hotkey to start, press stop key to stop (default)
-  # "push_to_talk" = hold hotkey to record, release to stop and transcribe
-  recording_mode: toggle
+    # Recording mode
+    # "toggle" = press hotkey to start, press stop key to stop (default)
+    # "push_to_talk" = hold hotkey to record, release to stop and transcribe
+    recording_mode: toggle
 
-  # Key combination for voice command mode
-  # Records speech and matches against user-defined commands
-  command_hotkey: "alt+win | macos: fn+command"
+    # Key combination for voice command mode
+    # Records speech and matches against user-defined commands
+    command_hotkey: "alt+win | macos: fn+command"
 
 vad: # Voice Activity Detection (VAD)
+    # Voice Activity Detection (VAD) Pre-check
+    # Uses TEN VAD to detect speech before transcription (prevents hallucinations on silence)
+    # NOTE: This is separate from faster-whisper's built-in VAD
+    vad_precheck_enabled: true
 
-  # Voice Activity Detection (VAD) Pre-check
-  # Uses TEN VAD to detect speech before transcription (prevents hallucinations on silence)
-  # NOTE: This is separate from faster-whisper's built-in VAD
-  vad_precheck_enabled: true
+    # TEN VAD Hysteresis Thresholds (prevent flickering on borderline audio)
+    vad_onset_threshold: 0.7 # Probability to START detecting speech (0.0-1.0)
+    vad_offset_threshold: 0.55 # Probability to STOP detecting speech (0.0-1.0)
 
-  # TEN VAD Hysteresis Thresholds (prevent flickering on borderline audio)
-  vad_onset_threshold: 0.7    # Probability to START detecting speech (0.0-1.0)
-  vad_offset_threshold: 0.55  # Probability to STOP detecting speech (0.0-1.0)
+    # Minimum Duration Filtering
+    vad_min_speech_duration: 0.1 # Minimum speech segment length in seconds (filters brief noise)
 
-  # Minimum Duration Filtering
-  vad_min_speech_duration: 0.1  # Minimum speech segment length in seconds (filters brief noise)
-
-  # Real-time VAD monitoring during recording
-  vad_realtime_enabled: true  # Enables continuous silence detection and automatic recording stop
-  vad_silence_timeout_seconds: 30.0  # Auto-stop recording after this many seconds of silence
+    # Real-time VAD monitoring during recording
+    vad_realtime_enabled: true # Enables continuous silence detection and automatic recording stop
+    vad_silence_timeout_seconds: 30.0 # Auto-stop recording after this many seconds of silence
 
 audio: # Audio Recording Settings
+    # Sample rate is fixed at 16000 Hz for optimal Whisper and TEN VAD performance
 
-  # Sample rate is fixed at 16000 Hz for optimal Whisper and TEN VAD performance
+    # Audio host API selection
+    # null = let Whisper Key choose the best option (WASAPI on Windows, first available elsewhere)
+    # e.g., "WASAPI", "MME", "DirectSound", "Core Audio"
+    host: null
 
-  # Audio host API selection
-  # null = let Whisper Key choose the best option (WASAPI on Windows, first available elsewhere)
-  # e.g., "WASAPI", "MME", "DirectSound", "Core Audio"
-  host: null
+    # Audio channels
+    # 1 = mono (recommended for speech)
+    # 2 = stereo
+    channels: 1
 
-  # Audio channels
-  # 1 = mono (recommended for speech)
-  # 2 = stereo
-  channels: 1
+    # Recording format
+    # Options: "float32", "int16", "int24", "int32"
+    # float32 recommended for best quality
+    dtype: float32
 
-  # Recording format
-  # Options: "float32", "int16", "int24", "int32"
-  # float32 recommended for best quality
-  dtype: float32
+    # Maximum recording duration (seconds)
+    # Set to 0 for unlimited recording
+    max_duration: 900
 
-  # Maximum recording duration (seconds)
-  # Set to 0 for unlimited recording
-  max_duration: 900
-
-  # Audio input device selection
-  # "default" = Use system default microphone (default behavior)
-  # <device_id> = Specific device ID number (set automatically when changed via system tray)
-  #
-  # Note: Device IDs are assigned by the operating system and may change if devices
-  # are plugged/unplugged. Use system tray to select device - it will save the ID here.
-  input_device: "default"
+    # Audio input device selection
+    # "default" = Use system default microphone (default behavior)
+    # <device_id> = Specific device ID number (set automatically when changed via system tray)
+    #
+    # Note: Device IDs are assigned by the operating system and may change if devices
+    # are plugged/unplugged. Use system tray to select device - it will save the ID here.
+    input_device: "default"
 
 clipboard: # Clipboard Behavior
+    # Automatically paste after transcription
+    # true = paste immediately to active window
+    # false = only copy to clipboard (paste manually)
+    auto_paste: true
 
-  # Automatically paste after transcription
-  # true = paste immediately to active window
-  # false = only copy to clipboard (paste manually)
-  auto_paste: true
+    # Delivery method for auto-paste
+    # "paste" = clipboard copy + simulated Ctrl+V paste
+    # "type" = direct text injection (Windows only)
+    #     Avoids clipboard manipulation and sends keys individually
+    delivery_method: "paste"
 
-  # Delivery method for auto-paste
-  # "paste" = clipboard copy + simulated Ctrl+V paste
-  # "type" = direct text injection (Windows only)
-  #     Avoids clipboard manipulation and sends keys individually
-  delivery_method: "paste"
+    # Key combination to simulate paste (only used when delivery_method is "paste")
+    # Format: modifier+key (use lowercase)
+    # Examples:
+    #   - "ctrl+v"         (standard paste)
+    #   - "ctrl+shift+v"   (plain text paste in some apps)
+    #   - "shift+insert"   (terminal paste)
+    paste_hotkey: "ctrl+v | macos: cmd+v"
 
-  # Key combination to simulate paste (only used when delivery_method is "paste")
-  # Format: modifier+key (use lowercase)
-  # Examples:
-  #   - "ctrl+v"         (standard paste)
-  #   - "ctrl+shift+v"   (plain text paste in some apps)
-  #   - "shift+insert"   (terminal paste)
-  paste_hotkey: "ctrl+v | macos: cmd+v"
+    # Delay after clipboard copy, before sending paste hotkey (seconds, paste mode)
+    # Lets clipboard listeners (e.g. Windows Clipboard History) finish reading
+    paste_pre_paste_delay: 0.05
 
-  # Delay after clipboard copy, before sending paste hotkey (seconds, paste mode)
-  # Lets clipboard listeners (e.g. Windows Clipboard History) finish reading
-  paste_pre_paste_delay: 0.05
+    # Restore original clipboard contents after delivery (paste mode)
+    paste_preserve_clipboard: true
 
-  # Restore original clipboard contents after delivery (paste mode)
-  paste_preserve_clipboard: true
+    # Delay before clipboard restore (seconds, paste mode)
+    paste_clipboard_restore_delay: 0.5
 
-  # Delay before clipboard restore (seconds, paste mode)
-  paste_clipboard_restore_delay: 0.5
+    # Also copy transcription to clipboard after delivery (type mode)
+    type_also_copy_to_clipboard: false
 
-  # Also copy transcription to clipboard after delivery (type mode)
-  type_also_copy_to_clipboard: false
+    # Delay before sending ENTER key after text injection (seconds, type mode)
+    # Terminal apps need time to process typed characters before Enter submits
+    # Total delay = type_auto_enter_delay + (characters / 100 * type_auto_enter_delay_per_100_chars)
+    type_auto_enter_delay: 0.15
+    type_auto_enter_delay_per_100_chars: 0.1
 
-  # Delay before sending ENTER key after text injection (seconds, type mode)
-  # Terminal apps need time to process typed characters before Enter submits
-  # Total delay = type_auto_enter_delay + (characters / 100 * type_auto_enter_delay_per_100_chars)
-  type_auto_enter_delay: 0.15
-  type_auto_enter_delay_per_100_chars: 0.1
-
-  # Delay for key simulation operations (seconds)
-  # Small delay ensures operations complete reliably (macOS only)
-  macos_key_simulation_delay: 0.05
+    # Delay for key simulation operations (seconds)
+    # Small delay ensures operations complete reliably (macOS only)
+    macos_key_simulation_delay: 0.05
 
 logging: # Logging Configuration
+    # Log level - how much detail to log
+    # Options: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
+    # - DEBUG: Very detailed (for troubleshooting)
+    # - INFO: General information (recommended)
+    # - WARNING: Only warnings and errors
+    # - ERROR: Only errors
+    level: INFO
 
-  # Log level - how much detail to log
-  # Options: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
-  # - DEBUG: Very detailed (for troubleshooting)
-  # - INFO: General information (recommended)
-  # - WARNING: Only warnings and errors
-  # - ERROR: Only errors
-  level: INFO
-  
-  # Log file settings
-  file:
-    enabled: true
-    filename: app.log
-  
-  # Log transcription text content to log file
-  # false = only log metadata (char count, language, timing) for privacy
-  # true = include actual transcribed text in log entries
-  log_transcriptions: false
+    # Log file settings
+    file:
+        enabled: true
+        filename: app.log
 
-  # Console output
-  console:
-    enabled: true
-    level: WARNING  # Console log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) - WARNING shows important messages only
+    # Log transcription text content to log file
+    # false = only log metadata (char count, language, timing) for privacy
+    # true = include actual transcribed text in log entries
+    log_transcriptions: false
 
+    # Console output
+    console:
+        enabled: true
+        level: WARNING # Console log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) - WARNING shows important messages only
 
 audio_feedback: # Audio Feedback Settings
+    # Enable/disable audio feedback sounds
+    # true = play sounds when recording starts/stops
+    # false = silent operation
+    enabled: true
 
-  # Enable/disable audio feedback sounds
-  # true = play sounds when recording starts/stops
-  # false = silent operation
-  enabled: true
+    # Enable/disable audio feedback sounds when transcription stops
+    # true = play sounds when transcription stops
+    # false = silent operation
+    transcription_complete_enabled: false
 
-  # Enable/disable audio feedback sounds when transcription stops
-  # true = play sounds when transcription stops
-  # false = silent operation
-  transcription_complete_enabled: false
-
-  # Sound file paths (relative to project root or absolute paths)
-  # Use .wav files for best Windows compatibility
-  start_sound: assets/sounds/record_start.wav
-  stop_sound: assets/sounds/record_stop.wav
-  cancel_sound: assets/sounds/record_cancel.wav
-  transcription_complete_sound: assets/sounds/transcription_complete.wav
+    # Sound file paths (relative to project root or absolute paths)
+    # Use .wav files for best Windows compatibility
+    start_sound: assets/sounds/record_start.wav
+    stop_sound: assets/sounds/record_stop.wav
+    cancel_sound: assets/sounds/record_cancel.wav
+    transcription_complete_sound: assets/sounds/transcription_complete.wav
 
 system_tray: # System Tray Settings
+    # Enable/disable system tray icon
+    # true = show icon in system tray with status and menu
+    # false = run without system tray (console mode only)
+    enabled: true
 
-  # Enable/disable system tray icon
-  # true = show icon in system tray with status and menu
-  # false = run without system tray (console mode only)
-  enabled: true
+    # Tooltip text when hovering over tray icon
+    tooltip: Whisper Key
 
-  # Tooltip text when hovering over tray icon
-  tooltip: Whisper Key
-
-console: # Console Window Management (exe mode only)
-
-  # Hide console window after startup (requires system tray)
-  start_hidden: false
+console: # Console Window Management (whisper-key-hideable.exe only)
+    # Hide console window after startup (requires system tray)
+    start_hidden: false
 
 update: # Update Settings
-
-  # How to handle available updates
-  # "prompt" = ask user before updating
-  # "auto" = update silently without asking
-  mode: prompt
+    # How to handle available updates
+    # "prompt" = ask user before updating
+    # "auto" = update silently without asking
+    mode: prompt
 
 onboarding: # First-run setup state (managed automatically)
+    # GPU acceleration setup status
+    # pending | no_gpu | skipped | complete
+    gpu: pending
 
-  # GPU acceleration setup status
-  # pending | no_gpu | skipped | complete
-  gpu: pending
-
-  # Detected GPU class (set automatically)
-  # nvidia | amd_rdna2+ | amd_rdna1 | null
-  gpu_class: null
+    # Detected GPU class (set automatically)
+    # nvidia | amd_rdna2+ | amd_rdna1 | null
+    gpu_class: null
 
 voice_commands: # Voice Command Settings
-
-  # Enable/disable voice commands feature
-  # true = register command hotkey and load commands file
-  # false = disable voice commands entirely
-  # Define commands in commands.yaml (same folder as user_settings.yaml)
-  enabled: true
+    # Enable/disable voice commands feature
+    # true = register command hotkey and load commands file
+    # false = disable voice commands entirely
+    # Define commands in commands.yaml (same folder as user_settings.yaml)
+    enabled: true

--- a/src/whisper_key/config.defaults.yaml
+++ b/src/whisper_key/config.defaults.yaml
@@ -309,6 +309,11 @@ system_tray: # System Tray Settings
   # Tooltip text when hovering over tray icon
   tooltip: Whisper Key
 
+console: # Console Window Management (exe mode only)
+
+  # Hide console window after startup (requires system tray)
+  start_hidden: false
+
 update: # Update Settings
 
   # How to handle available updates

--- a/src/whisper_key/config_manager.py
+++ b/src/whisper_key/config_manager.py
@@ -304,6 +304,9 @@ class ConfigManager:
     def get_voice_commands_config(self) -> Dict[str, Any]:
         return self.config.get('voice_commands', {}).copy()
 
+    def get_console_config(self) -> Dict[str, Any]:
+        return self.config.get('console', {}).copy()
+
     def get_update_config(self) -> Dict[str, Any]:
         return self.config.get('update', {}).copy()
 

--- a/src/whisper_key/main.py
+++ b/src/whisper_key/main.py
@@ -10,11 +10,7 @@ import signal
 import sys
 import threading
 
-sys.stdout.reconfigure(encoding='utf-8', errors='replace')
-sys.stdout.write("\033]0;Whisper Key\007")
-sys.stdout.flush()
-
-from .platform import app, permissions
+from .platform import app, permissions, console
 from .config_manager import ConfigManager
 from .audio_recorder import AudioRecorder
 from .hotkey_listener import HotkeyListener
@@ -144,12 +140,13 @@ def setup_voice_commands(voice_commands_config, clipboard_manager, log_transcrip
         log_transcriptions=log_transcriptions
     )
 
-def setup_system_tray(tray_config, config_manager, state_manager, model_registry):
+def setup_system_tray(tray_config, config_manager, state_manager, model_registry, console_config=None):
     return SystemTray(
         state_manager=state_manager,
         tray_config=tray_config,
         config_manager=config_manager,
-        model_registry=model_registry
+        model_registry=model_registry,
+        console_config=console_config
     )
 
 def run_gpu_onboarding(config_manager, whisper_config):
@@ -191,6 +188,10 @@ def shutdown_app(hotkey_listener: HotkeyListener, state_manager: StateManager, l
         state_manager.shutdown()
 
 def main():
+    console.setup()
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    sys.stdout.write("\033]0;Whisper Key\007")
+    sys.stdout.flush()
     app.setup()
 
     parser = argparse.ArgumentParser()
@@ -227,6 +228,7 @@ def main():
         vad_config = config_manager.get_vad_config()
         streaming_config = config_manager.get_streaming_config()
         voice_commands_config = config_manager.get_voice_commands_config()
+        console_config = config_manager.get_console_config()
         log_config = config_manager.get_logging_config()
         log_transcriptions = log_config.get('log_transcriptions', False)
 
@@ -255,7 +257,7 @@ def main():
             voice_command_manager=voice_command_manager
         )
         audio_recorder = setup_audio_recorder(audio_config, state_manager, vad_manager, streaming_manager)
-        system_tray = setup_system_tray(tray_config, config_manager, state_manager, model_registry)
+        system_tray = setup_system_tray(tray_config, config_manager, state_manager, model_registry, console_config)
         state_manager.attach_components(audio_recorder, system_tray)
         
         hotkey_listener = setup_hotkey_listener(hotkey_config, state_manager, voice_commands_config['enabled'])
@@ -272,6 +274,8 @@ def main():
         print("🚀 Whisper Key ready!")
         config_manager.print_startup_hotkey_instructions()
         print("   [CTRL+C] to quit", flush=True)
+
+        system_tray.apply_console_settings()
 
         app.run_event_loop(shutdown_event)
             

--- a/src/whisper_key/platform/__init__.py
+++ b/src/whisper_key/platform/__init__.py
@@ -5,6 +5,6 @@ IS_MACOS = PLATFORM == 'macos'
 IS_WINDOWS = PLATFORM == 'windows'
 
 if IS_MACOS:
-    from .macos import instance_lock, keyboard, hotkeys, paths, app, permissions, icons, gpu
+    from .macos import instance_lock, keyboard, hotkeys, paths, app, permissions, icons, gpu, console
 else:
-    from .windows import instance_lock, keyboard, hotkeys, paths, app, permissions, icons, gpu
+    from .windows import instance_lock, keyboard, hotkeys, paths, app, permissions, icons, gpu, console

--- a/src/whisper_key/platform/macos/console.py
+++ b/src/whisper_key/platform/macos/console.py
@@ -1,0 +1,22 @@
+def setup():
+    pass
+
+
+def owns_console():
+    return False
+
+
+def hide():
+    pass
+
+
+def show():
+    pass
+
+
+def is_minimized():
+    return False
+
+
+def start_minimize_monitor(on_minimize):
+    pass

--- a/src/whisper_key/platform/windows/console.py
+++ b/src/whisper_key/platform/windows/console.py
@@ -1,0 +1,197 @@
+import ctypes
+import ctypes.wintypes as wintypes
+import os
+import sys
+import threading
+
+user32 = ctypes.windll.user32
+kernel32 = ctypes.windll.kernel32
+
+SW_HIDE = 0
+SW_RESTORE = 9
+STD_OUTPUT_HANDLE = -11
+ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+ENABLE_PROCESSED_OUTPUT = 0x0001
+
+LF_FACESIZE = 32
+FF_MODERN = 0x30
+FIXED_PITCH = 0x01
+TMPF_TRUETYPE = 0x04
+
+_hwnd = None
+_active = False
+
+
+class COORD(ctypes.Structure):
+    _fields_ = [("X", ctypes.c_short), ("Y", ctypes.c_short)]
+
+
+class CONSOLE_FONT_INFOEX(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.ULONG),
+        ("nFont", wintypes.DWORD),
+        ("dwFontSize", COORD),
+        ("FontFamily", ctypes.c_uint),
+        ("FontWeight", ctypes.c_uint),
+        ("FaceName", ctypes.c_wchar * LF_FACESIZE),
+    ]
+
+
+class CONSOLE_SCREEN_BUFFER_INFOEX(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.ULONG),
+        ("dwSize", COORD),
+        ("dwCursorPosition", COORD),
+        ("wAttributes", wintypes.WORD),
+        ("srWindow", wintypes.SMALL_RECT),
+        ("dwMaximumWindowSize", COORD),
+        ("wPopupAttributes", wintypes.WORD),
+        ("bFullscreenSupported", wintypes.BOOL),
+        ("ColorTable", wintypes.DWORD * 16),
+    ]
+
+
+WINDOWS_TERMINAL_PALETTE = [
+    0x0C0C0C,  # 0  Black
+    0xC50F1F,  # 1  Dark Blue (stored as BGR: actually dark red)
+    0x13A10E,  # 2  Dark Green
+    0xC19C00,  # 3  Dark Cyan (actually dark yellow)
+    0x0037DA,  # 4  Dark Red (actually dark blue)
+    0x881798,  # 5  Dark Magenta
+    0xF9F1A5,  # 6  Dark Yellow (actually bright cyan-ish)
+    0xCCCCCC,  # 7  Gray
+    0x767676,  # 8  Dark Gray
+    0xE74856,  # 9  Blue (actually red)
+    0x16C60C,  # 10 Green
+    0xF9F1A5,  # 11 Cyan (actually bright yellow)
+    0x3B78FF,  # 12 Red (actually blue)
+    0xB4009E,  # 13 Magenta
+    0x61D6D6,  # 14 Yellow (actually cyan)
+    0xF2F2F2,  # 15 White
+]
+
+
+def _rgb_to_bgr(r, g, b):
+    return b << 16 | g << 8 | r
+
+
+CAMPBELL_PALETTE = [
+    _rgb_to_bgr(12, 12, 12),       # 0  Black
+    _rgb_to_bgr(197, 15, 31),      # 1  Dark Red
+    _rgb_to_bgr(19, 161, 14),      # 2  Dark Green
+    _rgb_to_bgr(193, 156, 0),      # 3  Dark Yellow
+    _rgb_to_bgr(0, 55, 218),       # 4  Dark Blue
+    _rgb_to_bgr(136, 23, 152),     # 5  Dark Magenta
+    _rgb_to_bgr(58, 150, 221),     # 6  Dark Cyan
+    _rgb_to_bgr(204, 204, 204),    # 7  Gray
+    _rgb_to_bgr(118, 118, 118),    # 8  Dark Gray
+    _rgb_to_bgr(231, 72, 86),      # 9  Red
+    _rgb_to_bgr(22, 198, 12),      # 10 Green
+    _rgb_to_bgr(249, 241, 165),    # 11 Yellow
+    _rgb_to_bgr(59, 120, 255),     # 12 Blue
+    _rgb_to_bgr(180, 0, 158),      # 13 Magenta
+    _rgb_to_bgr(97, 214, 214),     # 14 Cyan
+    _rgb_to_bgr(242, 242, 242),    # 15 White
+]
+
+
+def _get_hwnd():
+    global _hwnd
+    if _hwnd is None:
+        _hwnd = kernel32.GetConsoleWindow()
+    return _hwnd
+
+
+def _set_icon():
+    hwnd = _get_hwnd()
+    exe_path = os.environ.get("PYAPP", "")
+    if not hwnd or not exe_path:
+        return
+    WM_SETICON = 0x0080
+    ICON_SMALL = 0
+    ICON_BIG = 1
+    shell32 = ctypes.windll.shell32
+    icon_handle = shell32.ExtractIconW(0, exe_path, 0)
+    if icon_handle and icon_handle != 1:
+        user32.PostMessageW(hwnd, WM_SETICON, ICON_SMALL, icon_handle)
+        user32.PostMessageW(hwnd, WM_SETICON, ICON_BIG, icon_handle)
+
+
+def _configure_console():
+    kernel32.SetConsoleTitleW("Whisper Key")
+    _set_icon()
+
+    handle = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+
+    mode = wintypes.DWORD()
+    kernel32.GetConsoleMode(handle, ctypes.byref(mode))
+    mode.value |= ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_PROCESSED_OUTPUT
+    kernel32.SetConsoleMode(handle, mode)
+
+    font = CONSOLE_FONT_INFOEX()
+    font.cbSize = ctypes.sizeof(CONSOLE_FONT_INFOEX)
+    font.dwFontSize.X = 0
+    font.dwFontSize.Y = 22
+    font.FontFamily = FF_MODERN | FIXED_PITCH | TMPF_TRUETYPE
+    font.FontWeight = 400
+    font.FaceName = "Cascadia Mono"
+    kernel32.SetCurrentConsoleFontEx(handle, False, ctypes.byref(font))
+
+    info = CONSOLE_SCREEN_BUFFER_INFOEX()
+    info.cbSize = ctypes.sizeof(CONSOLE_SCREEN_BUFFER_INFOEX)
+    kernel32.GetConsoleScreenBufferInfoEx(handle, ctypes.byref(info))
+    for i, color in enumerate(CAMPBELL_PALETTE):
+        info.ColorTable[i] = color
+    info.srWindow.Bottom += 1
+    info.srWindow.Right += 1
+    kernel32.SetConsoleScreenBufferInfoEx(handle, ctypes.byref(info))
+
+
+def setup():
+    global _hwnd, _active
+    if not os.environ.get("PYAPP"):
+        return
+    kernel32.AllocConsole()
+    _hwnd = None
+    _get_hwnd()
+    sys.stdout = open("CONOUT$", "w", encoding="utf-8", errors="replace")
+    sys.stderr = open("CONOUT$", "w", encoding="utf-8", errors="replace")
+    sys.stdin = open("CONIN$", "r")
+    _configure_console()
+    _active = True
+
+
+def owns_console():
+    return _active
+
+
+def hide():
+    hwnd = _get_hwnd()
+    if hwnd:
+        user32.ShowWindow(hwnd, SW_HIDE)
+
+
+def show():
+    hwnd = _get_hwnd()
+    if hwnd:
+        user32.ShowWindow(hwnd, SW_HIDE)
+        user32.ShowWindow(hwnd, SW_RESTORE)
+        user32.SetForegroundWindow(hwnd)
+
+
+def is_minimized():
+    hwnd = _get_hwnd()
+    if not hwnd:
+        return False
+    return bool(user32.IsIconic(hwnd))
+
+
+def start_minimize_monitor(on_minimize):
+    def _poll():
+        while True:
+            if is_minimized():
+                on_minimize()
+            threading.Event().wait(0.2)
+
+    thread = threading.Thread(target=_poll, daemon=True)
+    thread.start()

--- a/src/whisper_key/platform/windows/console.py
+++ b/src/whisper_key/platform/windows/console.py
@@ -3,6 +3,7 @@ import ctypes.wintypes as wintypes
 import os
 import sys
 import threading
+import time
 
 user32 = ctypes.windll.user32
 kernel32 = ctypes.windll.kernel32
@@ -37,64 +38,6 @@ class CONSOLE_FONT_INFOEX(ctypes.Structure):
     ]
 
 
-class CONSOLE_SCREEN_BUFFER_INFOEX(ctypes.Structure):
-    _fields_ = [
-        ("cbSize", wintypes.ULONG),
-        ("dwSize", COORD),
-        ("dwCursorPosition", COORD),
-        ("wAttributes", wintypes.WORD),
-        ("srWindow", wintypes.SMALL_RECT),
-        ("dwMaximumWindowSize", COORD),
-        ("wPopupAttributes", wintypes.WORD),
-        ("bFullscreenSupported", wintypes.BOOL),
-        ("ColorTable", wintypes.DWORD * 16),
-    ]
-
-
-WINDOWS_TERMINAL_PALETTE = [
-    0x0C0C0C,  # 0  Black
-    0xC50F1F,  # 1  Dark Blue (stored as BGR: actually dark red)
-    0x13A10E,  # 2  Dark Green
-    0xC19C00,  # 3  Dark Cyan (actually dark yellow)
-    0x0037DA,  # 4  Dark Red (actually dark blue)
-    0x881798,  # 5  Dark Magenta
-    0xF9F1A5,  # 6  Dark Yellow (actually bright cyan-ish)
-    0xCCCCCC,  # 7  Gray
-    0x767676,  # 8  Dark Gray
-    0xE74856,  # 9  Blue (actually red)
-    0x16C60C,  # 10 Green
-    0xF9F1A5,  # 11 Cyan (actually bright yellow)
-    0x3B78FF,  # 12 Red (actually blue)
-    0xB4009E,  # 13 Magenta
-    0x61D6D6,  # 14 Yellow (actually cyan)
-    0xF2F2F2,  # 15 White
-]
-
-
-def _rgb_to_bgr(r, g, b):
-    return b << 16 | g << 8 | r
-
-
-CAMPBELL_PALETTE = [
-    _rgb_to_bgr(12, 12, 12),       # 0  Black
-    _rgb_to_bgr(197, 15, 31),      # 1  Dark Red
-    _rgb_to_bgr(19, 161, 14),      # 2  Dark Green
-    _rgb_to_bgr(193, 156, 0),      # 3  Dark Yellow
-    _rgb_to_bgr(0, 55, 218),       # 4  Dark Blue
-    _rgb_to_bgr(136, 23, 152),     # 5  Dark Magenta
-    _rgb_to_bgr(58, 150, 221),     # 6  Dark Cyan
-    _rgb_to_bgr(204, 204, 204),    # 7  Gray
-    _rgb_to_bgr(118, 118, 118),    # 8  Dark Gray
-    _rgb_to_bgr(231, 72, 86),      # 9  Red
-    _rgb_to_bgr(22, 198, 12),      # 10 Green
-    _rgb_to_bgr(249, 241, 165),    # 11 Yellow
-    _rgb_to_bgr(59, 120, 255),     # 12 Blue
-    _rgb_to_bgr(180, 0, 158),      # 13 Magenta
-    _rgb_to_bgr(97, 214, 214),     # 14 Cyan
-    _rgb_to_bgr(242, 242, 242),    # 15 White
-]
-
-
 def _get_hwnd():
     global _hwnd
     if _hwnd is None:
@@ -102,19 +45,21 @@ def _get_hwnd():
     return _hwnd
 
 
+WM_SETICON = 0x0080
+ICON_SMALL = 0
+ICON_BIG = 1
+
+
 def _set_icon():
     hwnd = _get_hwnd()
     exe_path = os.environ.get("PYAPP", "")
     if not hwnd or not exe_path:
         return
-    WM_SETICON = 0x0080
-    ICON_SMALL = 0
-    ICON_BIG = 1
     shell32 = ctypes.windll.shell32
     icon_handle = shell32.ExtractIconW(0, exe_path, 0)
     if icon_handle and icon_handle != 1:
-        user32.PostMessageW(hwnd, WM_SETICON, ICON_SMALL, icon_handle)
-        user32.PostMessageW(hwnd, WM_SETICON, ICON_BIG, icon_handle)
+        user32.SendMessageW(hwnd, WM_SETICON, ICON_SMALL, icon_handle)
+        user32.SendMessageW(hwnd, WM_SETICON, ICON_BIG, icon_handle)
 
 
 def _configure_console():
@@ -137,21 +82,13 @@ def _configure_console():
     font.FaceName = "Cascadia Mono"
     kernel32.SetCurrentConsoleFontEx(handle, False, ctypes.byref(font))
 
-    info = CONSOLE_SCREEN_BUFFER_INFOEX()
-    info.cbSize = ctypes.sizeof(CONSOLE_SCREEN_BUFFER_INFOEX)
-    kernel32.GetConsoleScreenBufferInfoEx(handle, ctypes.byref(info))
-    for i, color in enumerate(CAMPBELL_PALETTE):
-        info.ColorTable[i] = color
-    info.srWindow.Bottom += 1
-    info.srWindow.Right += 1
-    kernel32.SetConsoleScreenBufferInfoEx(handle, ctypes.byref(info))
-
 
 def setup():
     global _hwnd, _active
     if not os.environ.get("PYAPP"):
         return
-    kernel32.AllocConsole()
+    if not kernel32.AllocConsole():
+        return
     _hwnd = None
     _get_hwnd()
     sys.stdout = open("CONOUT$", "w", encoding="utf-8", errors="replace")
@@ -188,10 +125,15 @@ def is_minimized():
 
 def start_minimize_monitor(on_minimize):
     def _poll():
+        was_minimized = False
         while True:
             if is_minimized():
-                on_minimize()
-            threading.Event().wait(0.2)
+                if not was_minimized:
+                    on_minimize()
+                    was_minimized = True
+            else:
+                was_minimized = False
+            time.sleep(0.2)
 
     thread = threading.Thread(target=_poll, daemon=True)
     thread.start()

--- a/src/whisper_key/system_tray.py
+++ b/src/whisper_key/system_tray.py
@@ -298,7 +298,7 @@ class SystemTray:
         console.show()
 
     def apply_console_settings(self):
-        if not console.owns_console():
+        if not console.owns_console() or not self.available:
             return
         if self.console_config.get('start_hidden', False):
             console.hide()

--- a/src/whisper_key/system_tray.py
+++ b/src/whisper_key/system_tray.py
@@ -5,7 +5,7 @@ from typing import Optional, TYPE_CHECKING
 from pathlib import Path
 
 from .utils import open_file
-from .platform import permissions, icons
+from .platform import permissions, icons, console
 
 try:
     import pystray
@@ -25,12 +25,14 @@ class SystemTray:
                  state_manager: 'StateManager',
                  tray_config: dict = None,
                  config_manager: Optional['ConfigManager'] = None,
-                 model_registry = None):
+                 model_registry = None,
+                 console_config: dict = None):
 
         self.state_manager = state_manager
         self.tray_config = tray_config or {}
         self.config_manager = config_manager
         self.model_registry = model_registry
+        self.console_config = console_config or {}
         self.logger = logging.getLogger(__name__)
                
         self.icon = None  # pystray object, holds menu, state, etc.
@@ -170,7 +172,13 @@ class SystemTray:
 
             voice_commands_enabled = self.config_manager.get_setting('voice_commands', 'enabled')
 
-            menu_items = [
+            menu_items = []
+
+            if console.owns_console():
+                menu_items.append(pystray.MenuItem("Show Console", self._show_console, default=True))
+                menu_items.append(pystray.Menu.SEPARATOR)
+
+            menu_items += [
                 pystray.MenuItem("Open log file...", self._open_log_file),
                 pystray.MenuItem("Open model cache...", self._open_model_cache),
                 pystray.Menu.SEPARATOR,
@@ -285,6 +293,16 @@ class SystemTray:
             self.icon.menu = self._create_menu()
         else:
             self.logger.warning(f"Request to change audio device to {device_id} was not accepted")
+
+    def _show_console(self, icon=None, item=None):
+        console.show()
+
+    def apply_console_settings(self):
+        if not console.owns_console():
+            return
+        if self.console_config.get('start_hidden', False):
+            console.hide()
+        console.start_minimize_monitor(console.hide)
 
     def _quit_application_from_tray(self, icon=None, item=None):        
         os.kill(os.getpid(), signal.SIGINT)


### PR DESCRIPTION
## Summary
- Add console window management for pyapp exe mode (conhost via `PYAPP_IS_GUI`)
- Console setup: Cascadia Mono font, window title/icon, ANSI escape support
- System tray "Show Console" as default left-click action
- Minimize-to-tray with polling monitor
- `start_hidden` config option to hide console after startup
- Terminal mode (`python whisper-key.py`) skips all console management
- macOS: no-op stubs

## Caveats
Uses `PYAPP_IS_GUI` which forces conhost instead of Windows Terminal. Conhost has inferior emoji rendering and appearance. May ship as a separate `-tray.exe` build or not at all — depends on whether the tradeoff is worth it for users.

## Test plan
- [ ] Build pyapp exe with `PYAPP_IS_GUI=1`, set `start_hidden: true` → console hides after ready, tray click restores
- [ ] `start_hidden: false` → console stays visible, minimize hides to tray
- [ ] Run `python whisper-key.py` → no console management, normal behavior
- [ ] Tray disabled → no console management

🤖 Generated with [Claude Code](https://claude.com/claude-code)