### PR TITLE
fix(windows): strip key-state element from hotkey bindings

### DIFF
--- a/src/whisper_key/platform/windows/hotkeys.py
+++ b/src/whisper_key/platform/windows/hotkeys.py
@@ -19,7 +19,9 @@ def register(bindings: list):
     normalized = []
     for binding in bindings:
         hotkey_str = binding[0]
-        normalized_binding = [_normalize_hotkey(hotkey_str)] + binding[1:]
+        press_callback = binding[1]
+        release_callback = binding[2] if len(binding) > 2 else None
+        normalized_binding = [_normalize_hotkey(hotkey_str), press_callback, release_callback]
         normalized.append(normalized_binding)
     register_hotkeys(normalized)
 


### PR DESCRIPTION
global_hotkeys.register_hotkeys unpacks each binding as exactly 3 values (hotkey, press_cb, release_cb). After commit 7c5d6ce added push-to-talk, hotkey_listener started appending a 4th element (False key-state tracker) to each binding. windows/hotkeys.py was forwarding all elements via binding[1:], causing a 'too many values to unpack' crash that silently broke all hotkeys in push_to_talk mode.

Fix: explicitly extract only binding[1] and binding[2], constructing a clean 3-element list for register_hotkeys.