### PR TITLE
Fix stop key requiring two presses in toggle mode

### DIFF
--- a/src/whisper_key/hotkey_listener.py
+++ b/src/whisper_key/hotkey_listener.py
@@ -36,6 +36,7 @@ class HotkeyListener:
             hotkey_configs.append({
                 'combination': self.recording_hotkey,
                 'callback': self._standard_hotkey_pressed,
+                'release_callback': self._arm_keys_on_release,
                 'name': 'standard'
             })
 


### PR DESCRIPTION
Recording hotkey had no release_callback, so keys_armed stayed False after starting — the first stop key press was always ignored.